### PR TITLE
Use go-data for nice json un/marshaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: docs
+REPO:=github.com/tendermint/go-crypto
+
+docs:
+	@go get github.com/davecheney/godoc2md
+	godoc2md $(REPO) > README.md
+
+test:
+	go test ./...

--- a/armor_test.go
+++ b/armor_test.go
@@ -1,25 +1,20 @@
 package crypto
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleArmor(t *testing.T) {
 	blockType := "MINT TEST"
 	data := []byte("somedata")
 	armorStr := EncodeArmor(blockType, nil, data)
-	t.Log("Got armor: ", armorStr)
 
 	// Decode armorStr and test for equivalence.
 	blockType2, _, data2, err := DecodeArmor(armorStr)
-	if err != nil {
-		t.Error(err)
-	}
-	if blockType != blockType2 {
-		t.Errorf("Expected block type %v but got %v", blockType, blockType2)
-	}
-	if !bytes.Equal(data, data2) {
-		t.Errorf("Expected data %X but got %X", data2, data)
-	}
+	require.Nil(t, err, "%+v", err)
+	assert.Equal(t, blockType, blockType2)
+	assert.Equal(t, data, data2)
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -84,5 +84,29 @@ func TestKeyEncodings(t *testing.T) {
 		checkJSON(t, pubKey, &pub3, tc.keyName)
 		assert.EqualValues(t, pubKey, pub3)
 	}
+}
+
+func toFromJSON(t *testing.T, in interface{}, recvr interface{}) {
+	js, err := data.ToJSON(in)
+	require.Nil(t, err, "%+v", err)
+	err = data.FromJSON(js, recvr)
+	require.Nil(t, err, "%+v", err)
+}
+
+func TestNilEncodings(t *testing.T) {
+	// make sure sigs are okay with nil
+	a, b := SignatureS{}, SignatureS{}
+	toFromJSON(t, a, &b)
+	assert.EqualValues(t, a, b)
+
+	// make sure sigs are okay with nil
+	c, d := PubKeyS{}, PubKeyS{}
+	toFromJSON(t, c, &d)
+	assert.EqualValues(t, c, d)
+
+	// make sure sigs are okay with nil
+	e, f := PrivKeyS{}, PrivKeyS{}
+	toFromJSON(t, e, &f)
+	assert.EqualValues(t, e, f)
 
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -56,13 +56,13 @@ func TestKeyEncodings(t *testing.T) {
 	}{
 		{
 			privKey: PrivKeyS{GenPrivKeyEd25519()},
-			keyType: PrivKeyTypeEd25519,
-			keyName: PrivKeyNameEd25519,
+			keyType: TypeEd25519,
+			keyName: NameEd25519,
 		},
 		{
 			privKey: PrivKeyS{GenPrivKeySecp256k1()},
-			keyType: PrivKeyTypeSecp256k1,
-			keyName: PrivKeyNameSecp256k1,
+			keyType: TypeSecp256k1,
+			keyName: NameSecp256k1,
 		},
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,0 +1,88 @@
+package crypto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	data "github.com/tendermint/go-data"
+)
+
+type byter interface {
+	Bytes() []byte
+}
+
+// go to wire encoding and back
+func checkWire(t *testing.T, in byter, reader interface{}, typ byte) {
+	// test to and from binary
+	bin, err := data.ToWire(in)
+	require.Nil(t, err, "%+v", err)
+	assert.Equal(t, typ, bin[0])
+	// make sure this is compatible with current (Bytes()) encoding
+	assert.Equal(t, in.Bytes(), bin)
+
+	err = data.FromWire(bin, reader)
+	require.Nil(t, err, "%+v", err)
+}
+
+// go to json encoding and back
+func checkJSON(t *testing.T, in interface{}, reader interface{}, typ string) {
+	// test to and from binary
+	js, err := data.ToJSON(in)
+	require.Nil(t, err, "%+v", err)
+	styp := `"` + typ + `"`
+	assert.True(t, strings.Contains(string(js), styp))
+
+	err = data.FromJSON(js, reader)
+	require.Nil(t, err, "%+v", err)
+
+	// also check text format
+	text, err := data.ToText(in)
+	require.Nil(t, err, "%+v", err)
+	parts := strings.Split(text, ":")
+	require.Equal(t, 2, len(parts))
+	// make sure the first part is the typ string
+	assert.Equal(t, typ, parts[0])
+	// and the data is also present in the json
+	assert.True(t, strings.Contains(string(js), parts[1]))
+}
+
+func TestKeyEncodings(t *testing.T) {
+	cases := []struct {
+		privKey PrivKeyS
+		keyType byte
+		keyName string
+	}{
+		{
+			privKey: PrivKeyS{GenPrivKeyEd25519()},
+			keyType: PrivKeyTypeEd25519,
+			keyName: PrivKeyNameEd25519,
+		},
+		{
+			privKey: PrivKeyS{GenPrivKeySecp256k1()},
+			keyType: PrivKeyTypeSecp256k1,
+			keyName: PrivKeyNameSecp256k1,
+		},
+	}
+
+	for _, tc := range cases {
+		// check (de/en)codings of private key
+		priv2 := PrivKeyS{}
+		checkWire(t, tc.privKey, &priv2, tc.keyType)
+		assert.EqualValues(t, tc.privKey, priv2)
+		priv3 := PrivKeyS{}
+		checkJSON(t, tc.privKey, &priv3, tc.keyName)
+		assert.EqualValues(t, tc.privKey, priv3)
+
+		// check (de/en)codings of public key
+		pubKey := PubKeyS{tc.privKey.PubKey()}
+		pub2 := PubKeyS{}
+		checkWire(t, pubKey, &pub2, tc.keyType)
+		assert.EqualValues(t, pubKey, pub2)
+		pub3 := PubKeyS{}
+		checkJSON(t, pubKey, &pub3, tc.keyName)
+		assert.EqualValues(t, pubKey, pub3)
+	}
+
+}

--- a/priv_key.go
+++ b/priv_key.go
@@ -53,6 +53,10 @@ func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+func (p PrivKeyS) Empty() bool {
+	return p.PrivKey == nil
+}
+
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
 	err = wire.ReadBinaryBytes(privKeyBytes, &privKey)
 	return

--- a/priv_key.go
+++ b/priv_key.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tendermint/ed25519"
 	"github.com/tendermint/ed25519/extra25519"
 	. "github.com/tendermint/go-common"
+	data "github.com/tendermint/go-data"
 	"github.com/tendermint/go-wire"
 )
 
@@ -22,14 +23,35 @@ type PrivKey interface {
 const (
 	PrivKeyTypeEd25519   = byte(0x01)
 	PrivKeyTypeSecp256k1 = byte(0x02)
+	PrivKeyNameEd25519   = "ed25519"
+	PrivKeyNameSecp256k1 = "secp256k1"
 )
 
-// for wire.readReflect
-var _ = wire.RegisterInterface(
-	struct{ PrivKey }{},
-	wire.ConcreteType{PrivKeyEd25519{}, PrivKeyTypeEd25519},
-	wire.ConcreteType{PrivKeySecp256k1{}, PrivKeyTypeSecp256k1},
-)
+var privKeyMapper data.Mapper
+
+// register both private key types with go-data (and thus go-wire)
+func init() {
+	privKeyMapper = data.NewMapper(PrivKeyS{}).
+		RegisterInterface(PrivKeyEd25519{}, PrivKeyNameEd25519, PrivKeyTypeEd25519).
+		RegisterInterface(PrivKeySecp256k1{}, PrivKeyNameSecp256k1, PrivKeyTypeSecp256k1)
+}
+
+// PrivKeyS add json serialization to PrivKey
+type PrivKeyS struct {
+	PrivKey
+}
+
+func (p PrivKeyS) MarshalJSON() ([]byte, error) {
+	return privKeyMapper.ToJSON(p.PrivKey)
+}
+
+func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error) {
+	parsed, err := privKeyMapper.FromJSON(data)
+	if err == nil {
+		p.PrivKey = parsed.(PrivKey)
+	}
+	return
+}
 
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
 	err = wire.ReadBinaryBytes(privKeyBytes, &privKey)
@@ -62,6 +84,17 @@ func (privKey PrivKeyEd25519) Equals(other PrivKey) bool {
 	} else {
 		return false
 	}
+}
+
+func (p PrivKeyEd25519) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p[:])
+}
+
+func (p *PrivKeyEd25519) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(p[:], ref)
+	return err
 }
 
 func (privKey PrivKeyEd25519) ToCurve25519() *[32]byte {
@@ -134,6 +167,17 @@ func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool {
 	} else {
 		return false
 	}
+}
+
+func (p PrivKeySecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p[:])
+}
+
+func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(p[:], ref)
+	return err
 }
 
 func (privKey PrivKeySecp256k1) String() string {

--- a/priv_key.go
+++ b/priv_key.go
@@ -47,7 +47,7 @@ func (p PrivKeyS) MarshalJSON() ([]byte, error) {
 
 func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error) {
 	parsed, err := privKeyMapper.FromJSON(data)
-	if err == nil {
+	if err == nil && parsed != nil {
 		p.PrivKey = parsed.(PrivKey)
 	}
 	return

--- a/priv_key.go
+++ b/priv_key.go
@@ -19,12 +19,12 @@ type PrivKey interface {
 	Equals(PrivKey) bool
 }
 
-// Types of PrivKey implementations
+// Types of implementations
 const (
-	PrivKeyTypeEd25519   = byte(0x01)
-	PrivKeyTypeSecp256k1 = byte(0x02)
-	PrivKeyNameEd25519   = "ed25519"
-	PrivKeyNameSecp256k1 = "secp256k1"
+	TypeEd25519   = byte(0x01)
+	TypeSecp256k1 = byte(0x02)
+	NameEd25519   = "ed25519"
+	NameSecp256k1 = "secp256k1"
 )
 
 var privKeyMapper data.Mapper
@@ -32,8 +32,8 @@ var privKeyMapper data.Mapper
 // register both private key types with go-data (and thus go-wire)
 func init() {
 	privKeyMapper = data.NewMapper(PrivKeyS{}).
-		RegisterInterface(PrivKeyEd25519{}, PrivKeyNameEd25519, PrivKeyTypeEd25519).
-		RegisterInterface(PrivKeySecp256k1{}, PrivKeyNameSecp256k1, PrivKeyTypeSecp256k1)
+		RegisterInterface(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
+		RegisterInterface(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
 // PrivKeyS add json serialization to PrivKey

--- a/pub_key.go
+++ b/pub_key.go
@@ -55,6 +55,10 @@ func (p *PubKeyS) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+func (p PubKeyS) Empty() bool {
+	return p.PubKey == nil
+}
+
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
 	err = wire.ReadBinaryBytes(pubKeyBytes, &pubKey)
 	return

--- a/pub_key.go
+++ b/pub_key.go
@@ -21,21 +21,13 @@ type PubKey interface {
 	Equals(PubKey) bool
 }
 
-// Types of PubKey implementations
-const (
-	PubKeyTypeEd25519   = byte(0x01)
-	PubKeyTypeSecp256k1 = byte(0x02)
-	PubKeyNameEd25519   = "ed25519"
-	PubKeyNameSecp256k1 = "secp256k1"
-)
-
 var pubKeyMapper data.Mapper
 
 // register both public key types with go-data (and thus go-wire)
 func init() {
 	pubKeyMapper = data.NewMapper(PubKeyS{}).
-		RegisterInterface(PubKeyEd25519{}, PubKeyNameEd25519, PubKeyTypeEd25519).
-		RegisterInterface(PubKeySecp256k1{}, PubKeyNameSecp256k1, PubKeyTypeSecp256k1)
+		RegisterInterface(PubKeyEd25519{}, NameEd25519, TypeEd25519).
+		RegisterInterface(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
 // PubKeyS add json serialization to PubKey
@@ -76,7 +68,7 @@ func (pubKey PubKeyEd25519) Address() []byte {
 		PanicCrisis(*err)
 	}
 	// append type byte
-	encodedPubkey := append([]byte{PubKeyTypeEd25519}, w.Bytes()...)
+	encodedPubkey := append([]byte{TypeEd25519}, w.Bytes()...)
 	hasher := ripemd160.New()
 	hasher.Write(encodedPubkey) // does not error
 	return hasher.Sum(nil)
@@ -153,7 +145,7 @@ func (pubKey PubKeySecp256k1) Address() []byte {
 		PanicCrisis(*err)
 	}
 	// append type byte
-	encodedPubkey := append([]byte{PubKeyTypeSecp256k1}, w.Bytes()...)
+	encodedPubkey := append([]byte{TypeSecp256k1}, w.Bytes()...)
 	hasher := ripemd160.New()
 	hasher.Write(encodedPubkey) // does not error
 	return hasher.Sum(nil)

--- a/pub_key.go
+++ b/pub_key.go
@@ -49,7 +49,7 @@ func (p PubKeyS) MarshalJSON() ([]byte, error) {
 
 func (p *PubKeyS) UnmarshalJSON(data []byte) (err error) {
 	parsed, err := pubKeyMapper.FromJSON(data)
-	if err == nil {
+	if err == nil && parsed != nil {
 		p.PubKey = parsed.(PubKey)
 	}
 	return

--- a/signature.go
+++ b/signature.go
@@ -45,7 +45,7 @@ func (p SignatureS) MarshalJSON() ([]byte, error) {
 
 func (p *SignatureS) UnmarshalJSON(data []byte) (err error) {
 	parsed, err := sigMapper.FromJSON(data)
-	if err == nil {
+	if err == nil && parsed != nil {
 		p.Signature = parsed.(Signature)
 	}
 	return

--- a/signature.go
+++ b/signature.go
@@ -91,7 +91,7 @@ func (p *SignatureEd25519) UnmarshalJSON(enc []byte) error {
 //-------------------------------------
 
 // Implements Signature
-type SignatureSecp256k1 data.Bytes
+type SignatureSecp256k1 []byte
 
 func (sig SignatureSecp256k1) Bytes() []byte {
 	return wire.BinaryBytes(struct{ Signature }{sig})
@@ -107,4 +107,11 @@ func (sig SignatureSecp256k1) Equals(other Signature) bool {
 	} else {
 		return false
 	}
+}
+func (p SignatureSecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p)
+}
+
+func (p *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
+	return data.Encoder.Unmarshal((*[]byte)(p), enc)
 }

--- a/signature.go
+++ b/signature.go
@@ -51,6 +51,10 @@ func (p *SignatureS) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+func (p SignatureS) Empty() bool {
+	return p.Signature == nil
+}
+
 func SignatureFromBytes(sigBytes []byte) (sig Signature, err error) {
 	err = wire.ReadBinaryBytes(sigBytes, &sig)
 	return

--- a/signature.go
+++ b/signature.go
@@ -17,21 +17,13 @@ type Signature interface {
 	Equals(Signature) bool
 }
 
-// Types of Signature implementations
-const (
-	SignatureTypeEd25519   = byte(0x01)
-	SignatureTypeSecp256k1 = byte(0x02)
-	SignatureNameEd25519   = "ed25519"
-	SignatureNameSecp256k1 = "secp256k1"
-)
-
 var sigMapper data.Mapper
 
 // register both public key types with go-data (and thus go-wire)
 func init() {
 	sigMapper = data.NewMapper(SignatureS{}).
-		RegisterInterface(SignatureEd25519{}, SignatureNameEd25519, SignatureTypeEd25519).
-		RegisterInterface(SignatureSecp256k1{}, SignatureNameSecp256k1, SignatureTypeSecp256k1)
+		RegisterInterface(SignatureEd25519{}, NameEd25519, TypeEd25519).
+		RegisterInterface(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
 // SignatureS add json serialization to Signature

--- a/signature_test.go
+++ b/signature_test.go
@@ -56,14 +56,14 @@ func TestSignatureEncodings(t *testing.T) {
 		{
 			privKey: PrivKeyS{GenPrivKeyEd25519()},
 			sigSize: ed25519.SignatureSize,
-			sigType: SignatureTypeEd25519,
-			sigName: SignatureNameEd25519,
+			sigType: TypeEd25519,
+			sigName: NameEd25519,
 		},
 		{
 			privKey: PrivKeyS{GenPrivKeySecp256k1()},
 			sigSize: 0, // unknown
-			sigType: SignatureTypeSecp256k1,
-			sigName: SignatureNameSecp256k1,
+			sigType: TypeSecp256k1,
+			sigName: NameSecp256k1,
 		},
 	}
 

--- a/signature_test.go
+++ b/signature_test.go
@@ -1,11 +1,14 @@
 package crypto
 
 import (
-	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/ed25519"
-	"github.com/tendermint/go-wire"
+	data "github.com/tendermint/go-data"
 )
 
 func TestSignAndValidateEd25519(t *testing.T) {
@@ -56,68 +59,60 @@ func TestSignAndValidateSecp256k1(t *testing.T) {
 	}
 }
 
-func TestBinaryDecodeEd25519(t *testing.T) {
-
-	privKey := GenPrivKeyEd25519()
-	pubKey := privKey.PubKey()
-
-	msg := CRandBytes(128)
-	sig := privKey.Sign(msg)
-	t.Logf("msg: %X, sig: %X", msg, sig)
-
-	buf, n, err := new(bytes.Buffer), new(int), new(error)
-	wire.WriteBinary(struct{ Signature }{sig}, buf, n, err)
-	if *err != nil {
-		t.Fatalf("Failed to write Signature: %v", err)
+func TestSignatureEncodings(t *testing.T) {
+	cases := []struct {
+		privKey PrivKeyS
+		sigSize int
+		sigType byte
+		sigName string
+	}{
+		{
+			privKey: PrivKeyS{GenPrivKeyEd25519()},
+			sigSize: ed25519.SignatureSize,
+			sigType: SignatureTypeEd25519,
+			sigName: SignatureNameEd25519,
+		},
+		{
+			privKey: PrivKeyS{GenPrivKeySecp256k1()},
+			sigSize: 0, // unknown
+			sigType: SignatureTypeSecp256k1,
+			sigName: SignatureNameSecp256k1,
+		},
 	}
 
-	if len(buf.Bytes()) != ed25519.SignatureSize+1 {
-		// 1 byte TypeByte, 64 bytes signature bytes
-		t.Fatalf("Unexpected signature write size: %v", len(buf.Bytes()))
-	}
-	if buf.Bytes()[0] != SignatureTypeEd25519 {
-		t.Fatalf("Unexpected signature type byte")
-	}
+	for _, tc := range cases {
+		// note we embed them from the beginning....
+		pubKey := PubKeyS{tc.privKey.PubKey()}
 
-	sigStruct := struct{ Signature }{}
-	sig2 := wire.ReadBinary(sigStruct, buf, 0, n, err)
-	if *err != nil {
-		t.Fatalf("Failed to read Signature: %v", err)
-	}
+		msg := CRandBytes(128)
+		sig := SignatureS{tc.privKey.Sign(msg)}
 
-	// Test the signature
-	if !pubKey.VerifyBytes(msg, sig2.(struct{ Signature }).Signature.(SignatureEd25519)) {
-		t.Errorf("Account message signature verification failed")
-	}
-}
+		// store as wire
+		bin, err := data.ToWire(sig)
+		require.Nil(t, err, "%+v", err)
+		if tc.sigSize != 0 {
+			assert.Equal(t, tc.sigSize+1, len(bin))
+		}
+		assert.Equal(t, tc.sigType, bin[0])
 
-func TestBinaryDecodeSecp256k1(t *testing.T) {
+		// and back
+		sig2 := SignatureS{}
+		err = data.FromWire(bin, &sig2)
+		require.Nil(t, err, "%+v", err)
+		assert.EqualValues(t, sig, sig2)
+		assert.True(t, pubKey.VerifyBytes(msg, sig2))
 
-	privKey := GenPrivKeySecp256k1()
-	pubKey := privKey.PubKey()
+		// store as json
+		js, err := data.ToJSON(sig)
+		require.Nil(t, err, "%+v", err)
+		assert.True(t, strings.Contains(string(js), tc.sigName))
+		fmt.Println(string(js))
 
-	msg := CRandBytes(128)
-	sig := privKey.Sign(msg)
-	t.Logf("msg: %X, sig: %X", msg, sig)
-
-	buf, n, err := new(bytes.Buffer), new(int), new(error)
-	wire.WriteBinary(struct{ Signature }{sig}, buf, n, err)
-	if *err != nil {
-		t.Fatalf("Failed to write Signature: %v", err)
-	}
-
-	if buf.Bytes()[0] != SignatureTypeSecp256k1 {
-		t.Fatalf("Unexpected signature type byte")
-	}
-
-	sigStruct := struct{ Signature }{}
-	sig2 := wire.ReadBinary(sigStruct, buf, 0, n, err)
-	if *err != nil {
-		t.Fatalf("Failed to read Signature: %v", err)
-	}
-
-	// Test the signature
-	if !pubKey.VerifyBytes(msg, sig2.(struct{ Signature }).Signature.(SignatureSecp256k1)) {
-		t.Errorf("Account message signature verification failed")
+		// and back
+		sig3 := SignatureS{}
+		err = data.FromJSON(js, &sig3)
+		require.Nil(t, err, "%+v", err)
+		assert.EqualValues(t, sig, sig3)
+		assert.True(t, pubKey.VerifyBytes(msg, sig3))
 	}
 }

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -1,8 +1,10 @@
 package crypto
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -14,16 +16,10 @@ func TestSimple(t *testing.T) {
 	plaintext := []byte("sometext")
 	secret := []byte("somesecretoflengththirtytwo===32")
 	ciphertext := EncryptSymmetric(plaintext, secret)
-
 	plaintext2, err := DecryptSymmetric(ciphertext, secret)
-	if err != nil {
-		t.Error(err)
-	}
 
-	if !bytes.Equal(plaintext, plaintext2) {
-		t.Errorf("Decrypted plaintext was %X, expected %X", plaintext2, plaintext)
-	}
-
+	require.Nil(t, err, "%+v", err)
+	assert.Equal(t, plaintext, plaintext2)
 }
 
 func TestSimpleWithKDF(t *testing.T) {
@@ -39,14 +35,8 @@ func TestSimpleWithKDF(t *testing.T) {
 	secret = Sha256(secret)
 
 	ciphertext := EncryptSymmetric(plaintext, secret)
-
 	plaintext2, err := DecryptSymmetric(ciphertext, secret)
-	if err != nil {
-		t.Error(err)
-	}
 
-	if !bytes.Equal(plaintext, plaintext2) {
-		t.Errorf("Decrypted plaintext was %X, expected %X", plaintext2, plaintext)
-	}
-
+	require.Nil(t, err, "%+v", err)
+	assert.Equal(t, plaintext, plaintext2)
 }


### PR DESCRIPTION
Another approach to solve #1 

This uses wrapping structs to allow json unmarshalling of interfaces with minimal boilerplate code (which I hope to auto-generate one day). The default behavior with wire.BinaryBytes() and wire.JSONBytes() is not changed at all.

If you use the `encoding/json` library, we get nice handling of the three interfaces, `PubKey`, `PrivKey` and `Signature`.  You must just store them in a wrapping struct: `PubKeyS`, `PrivKeyS` or `SignatureS`.  Please take a look at the tests.

We use `go-data` to export all byte slices (and with custom JSONMarshal also the byte arrays) as hex strings.  However this is flexible, and you can set the byte encoding to use hex, base64 or base58 in the main entry of your program and it will affect the encoding of all types that make use of `data.Bytes` or `data.Encoder`.

Example default encodings are for public keys are:

```
{
	"type": "ed25519",
	"data": "345347cee043dc6d6f70b0ae9a3fc5a8c977006fd13000680b1e2afecd0475d5"
}

{
	"type": "secp256k1",
	"data": "989f04749bcc689f6dec7489cc227bc3e2fbc4c37067df8750e0791d2e6297c106e244fc635ecd1696698dfd8d49efa752bb3ad7ff8c7fd23b79743cce8476b8"
}
```

If you use `crypto.PubKeyS` in your structs, you can cleanly Unmarshal this json into usable PubKey's as well.