### PR TITLE
Reorg algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.swp
 *.swo
+vendor
+
+# these should be locked in the including repo, the dependencies are mainly
+# for testing and documentation
+glide.lock

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ docs:
 	godoc2md $(REPO) > README.md
 
 test:
-	go test ./...
+	go test `glide novendor`

--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@
 * [func Sha256(bytes []byte) []byte](#Sha256)
 * [type PrivKey](#PrivKey)
   * [func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error)](#PrivKeyFromBytes)
+  * [func (p PrivKey) Bytes() []byte](#PrivKey.Bytes)
+  * [func (p PrivKey) Empty() bool](#PrivKey.Empty)
+  * [func (p PrivKey) MarshalJSON() ([]byte, error)](#PrivKey.MarshalJSON)
+  * [func (p *PrivKey) UnmarshalJSON(data []byte) (err error)](#PrivKey.UnmarshalJSON)
+  * [func (p PrivKey) Unwrap() PrivKeyInner](#PrivKey.Unwrap)
 * [type PrivKeyEd25519](#PrivKeyEd25519)
   * [func GenPrivKeyEd25519() PrivKeyEd25519](#GenPrivKeyEd25519)
   * [func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519](#GenPrivKeyEd25519FromSecret)
-  * [func (privKey PrivKeyEd25519) Bytes() []byte](#PrivKeyEd25519.Bytes)
+  * [func (privKey PrivKeyEd25519) AssertIsPrivKeyInner()](#PrivKeyEd25519.AssertIsPrivKeyInner)
   * [func (privKey PrivKeyEd25519) Equals(other PrivKey) bool](#PrivKeyEd25519.Equals)
   * [func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519](#PrivKeyEd25519.Generate)
   * [func (p PrivKeyEd25519) MarshalJSON() ([]byte, error)](#PrivKeyEd25519.MarshalJSON)
@@ -37,25 +42,29 @@
   * [func (privKey PrivKeyEd25519) String() string](#PrivKeyEd25519.String)
   * [func (privKey PrivKeyEd25519) ToCurve25519() *[32]byte](#PrivKeyEd25519.ToCurve25519)
   * [func (p *PrivKeyEd25519) UnmarshalJSON(enc []byte) error](#PrivKeyEd25519.UnmarshalJSON)
-* [type PrivKeyS](#PrivKeyS)
-  * [func (p PrivKeyS) Empty() bool](#PrivKeyS.Empty)
-  * [func (p PrivKeyS) MarshalJSON() ([]byte, error)](#PrivKeyS.MarshalJSON)
-  * [func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error)](#PrivKeyS.UnmarshalJSON)
+  * [func (privKey PrivKeyEd25519) Wrap() PrivKey](#PrivKeyEd25519.Wrap)
+* [type PrivKeyInner](#PrivKeyInner)
 * [type PrivKeySecp256k1](#PrivKeySecp256k1)
   * [func GenPrivKeySecp256k1() PrivKeySecp256k1](#GenPrivKeySecp256k1)
   * [func GenPrivKeySecp256k1FromSecret(secret []byte) PrivKeySecp256k1](#GenPrivKeySecp256k1FromSecret)
-  * [func (privKey PrivKeySecp256k1) Bytes() []byte](#PrivKeySecp256k1.Bytes)
+  * [func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner()](#PrivKeySecp256k1.AssertIsPrivKeyInner)
   * [func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool](#PrivKeySecp256k1.Equals)
   * [func (p PrivKeySecp256k1) MarshalJSON() ([]byte, error)](#PrivKeySecp256k1.MarshalJSON)
   * [func (privKey PrivKeySecp256k1) PubKey() PubKey](#PrivKeySecp256k1.PubKey)
   * [func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature](#PrivKeySecp256k1.Sign)
   * [func (privKey PrivKeySecp256k1) String() string](#PrivKeySecp256k1.String)
   * [func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error](#PrivKeySecp256k1.UnmarshalJSON)
+  * [func (privKey PrivKeySecp256k1) Wrap() PrivKey](#PrivKeySecp256k1.Wrap)
 * [type PubKey](#PubKey)
   * [func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error)](#PubKeyFromBytes)
+  * [func (p PubKey) Bytes() []byte](#PubKey.Bytes)
+  * [func (p PubKey) Empty() bool](#PubKey.Empty)
+  * [func (pk PubKey) MarshalJSON() ([]byte, error)](#PubKey.MarshalJSON)
+  * [func (pk *PubKey) UnmarshalJSON(data []byte) (err error)](#PubKey.UnmarshalJSON)
+  * [func (pk PubKey) Unwrap() PubKeyInner](#PubKey.Unwrap)
 * [type PubKeyEd25519](#PubKeyEd25519)
   * [func (pubKey PubKeyEd25519) Address() []byte](#PubKeyEd25519.Address)
-  * [func (pubKey PubKeyEd25519) Bytes() []byte](#PubKeyEd25519.Bytes)
+  * [func (pubKey PubKeyEd25519) AssertIsPubKeyInner()](#PubKeyEd25519.AssertIsPubKeyInner)
   * [func (pubKey PubKeyEd25519) Equals(other PubKey) bool](#PubKeyEd25519.Equals)
   * [func (pubKey PubKeyEd25519) KeyString() string](#PubKeyEd25519.KeyString)
   * [func (p PubKeyEd25519) MarshalJSON() ([]byte, error)](#PubKeyEd25519.MarshalJSON)
@@ -63,43 +72,46 @@
   * [func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte](#PubKeyEd25519.ToCurve25519)
   * [func (p *PubKeyEd25519) UnmarshalJSON(enc []byte) error](#PubKeyEd25519.UnmarshalJSON)
   * [func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool](#PubKeyEd25519.VerifyBytes)
-* [type PubKeyS](#PubKeyS)
-  * [func (p PubKeyS) Empty() bool](#PubKeyS.Empty)
-  * [func (p PubKeyS) MarshalJSON() ([]byte, error)](#PubKeyS.MarshalJSON)
-  * [func (p *PubKeyS) UnmarshalJSON(data []byte) (err error)](#PubKeyS.UnmarshalJSON)
+  * [func (pubKey PubKeyEd25519) Wrap() PubKey](#PubKeyEd25519.Wrap)
+* [type PubKeyInner](#PubKeyInner)
 * [type PubKeySecp256k1](#PubKeySecp256k1)
   * [func (pubKey PubKeySecp256k1) Address() []byte](#PubKeySecp256k1.Address)
-  * [func (pubKey PubKeySecp256k1) Bytes() []byte](#PubKeySecp256k1.Bytes)
+  * [func (pubKey PubKeySecp256k1) AssertIsPubKeyInner()](#PubKeySecp256k1.AssertIsPubKeyInner)
   * [func (pubKey PubKeySecp256k1) Equals(other PubKey) bool](#PubKeySecp256k1.Equals)
   * [func (pubKey PubKeySecp256k1) KeyString() string](#PubKeySecp256k1.KeyString)
   * [func (p PubKeySecp256k1) MarshalJSON() ([]byte, error)](#PubKeySecp256k1.MarshalJSON)
   * [func (pubKey PubKeySecp256k1) String() string](#PubKeySecp256k1.String)
   * [func (p *PubKeySecp256k1) UnmarshalJSON(enc []byte) error](#PubKeySecp256k1.UnmarshalJSON)
   * [func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool](#PubKeySecp256k1.VerifyBytes)
+  * [func (pubKey PubKeySecp256k1) Wrap() PubKey](#PubKeySecp256k1.Wrap)
 * [type Signature](#Signature)
   * [func SignatureFromBytes(sigBytes []byte) (sig Signature, err error)](#SignatureFromBytes)
+  * [func (s Signature) Bytes() []byte](#Signature.Bytes)
+  * [func (sig Signature) Empty() bool](#Signature.Empty)
+  * [func (sig Signature) MarshalJSON() ([]byte, error)](#Signature.MarshalJSON)
+  * [func (sig *Signature) UnmarshalJSON(data []byte) (err error)](#Signature.UnmarshalJSON)
+  * [func (sig Signature) Unwrap() SignatureInner](#Signature.Unwrap)
 * [type SignatureEd25519](#SignatureEd25519)
-  * [func (sig SignatureEd25519) Bytes() []byte](#SignatureEd25519.Bytes)
+  * [func (sig SignatureEd25519) AssertIsSignatureInner()](#SignatureEd25519.AssertIsSignatureInner)
   * [func (sig SignatureEd25519) Equals(other Signature) bool](#SignatureEd25519.Equals)
   * [func (sig SignatureEd25519) IsZero() bool](#SignatureEd25519.IsZero)
-  * [func (p SignatureEd25519) MarshalJSON() ([]byte, error)](#SignatureEd25519.MarshalJSON)
+  * [func (sig SignatureEd25519) MarshalJSON() ([]byte, error)](#SignatureEd25519.MarshalJSON)
   * [func (sig SignatureEd25519) String() string](#SignatureEd25519.String)
-  * [func (p *SignatureEd25519) UnmarshalJSON(enc []byte) error](#SignatureEd25519.UnmarshalJSON)
-* [type SignatureS](#SignatureS)
-  * [func (p SignatureS) Empty() bool](#SignatureS.Empty)
-  * [func (p SignatureS) MarshalJSON() ([]byte, error)](#SignatureS.MarshalJSON)
-  * [func (p *SignatureS) UnmarshalJSON(data []byte) (err error)](#SignatureS.UnmarshalJSON)
+  * [func (sig *SignatureEd25519) UnmarshalJSON(enc []byte) error](#SignatureEd25519.UnmarshalJSON)
+  * [func (sig SignatureEd25519) Wrap() Signature](#SignatureEd25519.Wrap)
+* [type SignatureInner](#SignatureInner)
 * [type SignatureSecp256k1](#SignatureSecp256k1)
-  * [func (sig SignatureSecp256k1) Bytes() []byte](#SignatureSecp256k1.Bytes)
+  * [func (sig SignatureSecp256k1) AssertIsSignatureInner()](#SignatureSecp256k1.AssertIsSignatureInner)
   * [func (sig SignatureSecp256k1) Equals(other Signature) bool](#SignatureSecp256k1.Equals)
   * [func (sig SignatureSecp256k1) IsZero() bool](#SignatureSecp256k1.IsZero)
-  * [func (p SignatureSecp256k1) MarshalJSON() ([]byte, error)](#SignatureSecp256k1.MarshalJSON)
+  * [func (sig SignatureSecp256k1) MarshalJSON() ([]byte, error)](#SignatureSecp256k1.MarshalJSON)
   * [func (sig SignatureSecp256k1) String() string](#SignatureSecp256k1.String)
-  * [func (p *SignatureSecp256k1) UnmarshalJSON(enc []byte) error](#SignatureSecp256k1.UnmarshalJSON)
+  * [func (sig *SignatureSecp256k1) UnmarshalJSON(enc []byte) error](#SignatureSecp256k1.UnmarshalJSON)
+  * [func (sig SignatureSecp256k1) Wrap() Signature](#SignatureSecp256k1.Wrap)
 
 
 #### <a name="pkg-files">Package files</a>
-[armor.go](/src/github.com/tendermint/go-crypto/armor.go) [hash.go](/src/github.com/tendermint/go-crypto/hash.go) [priv_key.go](/src/github.com/tendermint/go-crypto/priv_key.go) [pub_key.go](/src/github.com/tendermint/go-crypto/pub_key.go) [random.go](/src/github.com/tendermint/go-crypto/random.go) [signature.go](/src/github.com/tendermint/go-crypto/signature.go) [symmetric.go](/src/github.com/tendermint/go-crypto/symmetric.go) 
+[armor.go](/src/github.com/tendermint/go-crypto/armor.go) [crypto.go](/src/github.com/tendermint/go-crypto/crypto.go) [ed25519.go](/src/github.com/tendermint/go-crypto/ed25519.go) [hash.go](/src/github.com/tendermint/go-crypto/hash.go) [priv_key.go](/src/github.com/tendermint/go-crypto/priv_key.go) [pub_key.go](/src/github.com/tendermint/go-crypto/pub_key.go) [random.go](/src/github.com/tendermint/go-crypto/random.go) [secp256k1.go](/src/github.com/tendermint/go-crypto/secp256k1.go) [signature.go](/src/github.com/tendermint/go-crypto/signature.go) [symmetric.go](/src/github.com/tendermint/go-crypto/symmetric.go) 
 
 
 ## <a name="pkg-constants">Constants</a>
@@ -193,24 +205,19 @@ func Sha256(bytes []byte) []byte
 
 
 
-## <a name="PrivKey">type</a> [PrivKey](/src/target/priv_key.go?s=326:435#L5)
+## <a name="PrivKey">type</a> [PrivKey](/src/target/priv_key.go?s=280:333#L5)
 ``` go
-type PrivKey interface {
-    Bytes() []byte
-    Sign(msg []byte) Signature
-    PubKey() PubKey
-    Equals(PrivKey) bool
+type PrivKey struct {
+    PrivKeyInner `json:"unwrap"`
 }
 ```
-PrivKey is part of PrivAccount and state.PrivValidator.
 
 
 
 
 
 
-
-### <a name="PrivKeyFromBytes">func</a> [PrivKeyFromBytes](/src/target/priv_key.go?s=1302:1373#L50)
+### <a name="PrivKeyFromBytes">func</a> [PrivKeyFromBytes](/src/target/priv_key.go?s=99:170#L1)
 ``` go
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error)
 ```
@@ -218,7 +225,44 @@ func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error)
 
 
 
-## <a name="PrivKeyEd25519">type</a> [PrivKeyEd25519](/src/target/priv_key.go?s=1502:1530#L58)
+### <a name="PrivKey.Bytes">func</a> (PrivKey) [Bytes](/src/target/priv_key.go?s=587:618#L21)
+``` go
+func (p PrivKey) Bytes() []byte
+```
+
+
+
+### <a name="PrivKey.Empty">func</a> (PrivKey) [Empty](/src/target/priv_key.go?s=1190:1219#L46)
+``` go
+func (p PrivKey) Empty() bool
+```
+
+
+
+### <a name="PrivKey.MarshalJSON">func</a> (PrivKey) [MarshalJSON](/src/target/priv_key.go?s=652:698#L25)
+``` go
+func (p PrivKey) MarshalJSON() ([]byte, error)
+```
+
+
+
+### <a name="PrivKey.UnmarshalJSON">func</a> (\*PrivKey) [UnmarshalJSON](/src/target/priv_key.go?s=749:805#L29)
+``` go
+func (p *PrivKey) UnmarshalJSON(data []byte) (err error)
+```
+
+
+
+### <a name="PrivKey.Unwrap">func</a> (PrivKey) [Unwrap](/src/target/priv_key.go?s=1024:1062#L38)
+``` go
+func (p PrivKey) Unwrap() PrivKeyInner
+```
+Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+
+
+
+
+## <a name="PrivKeyEd25519">type</a> [PrivKeyEd25519](/src/target/ed25519.go?s=632:660#L17)
 ``` go
 type PrivKeyEd25519 [64]byte
 ```
@@ -230,12 +274,12 @@ Implements PrivKey
 
 
 
-### <a name="GenPrivKeyEd25519">func</a> [GenPrivKeyEd25519](/src/target/priv_key.go?s=3003:3042#L116)
+### <a name="GenPrivKeyEd25519">func</a> [GenPrivKeyEd25519](/src/target/ed25519.go?s=2211:2250#L78)
 ``` go
 func GenPrivKeyEd25519() PrivKeyEd25519
 ```
 
-### <a name="GenPrivKeyEd25519FromSecret">func</a> [GenPrivKeyEd25519FromSecret](/src/target/priv_key.go?s=3290:3352#L125)
+### <a name="GenPrivKeyEd25519FromSecret">func</a> [GenPrivKeyEd25519FromSecret](/src/target/ed25519.go?s=2498:2560#L87)
 ``` go
 func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519
 ```
@@ -246,21 +290,21 @@ if it's derived from user input.
 
 
 
-### <a name="PrivKeyEd25519.Bytes">func</a> (PrivKeyEd25519) [Bytes](/src/target/priv_key.go?s=1532:1576#L60)
+### <a name="PrivKeyEd25519.AssertIsPrivKeyInner">func</a> (PrivKeyEd25519) [AssertIsPrivKeyInner](/src/target/ed25519.go?s=662:714#L19)
 ``` go
-func (privKey PrivKeyEd25519) Bytes() []byte
+func (privKey PrivKeyEd25519) AssertIsPrivKeyInner()
 ```
 
 
 
-### <a name="PrivKeyEd25519.Equals">func</a> (PrivKeyEd25519) [Equals](/src/target/priv_key.go?s=1973:2029#L75)
+### <a name="PrivKeyEd25519.Equals">func</a> (PrivKeyEd25519) [Equals](/src/target/ed25519.go?s=1093:1149#L33)
 ``` go
 func (privKey PrivKeyEd25519) Equals(other PrivKey) bool
 ```
 
 
 
-### <a name="PrivKeyEd25519.Generate">func</a> (PrivKeyEd25519) [Generate](/src/target/priv_key.go?s=2761:2825#L106)
+### <a name="PrivKeyEd25519.Generate">func</a> (PrivKeyEd25519) [Generate](/src/target/ed25519.go?s=1894:1958#L64)
 ``` go
 func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519
 ```
@@ -269,55 +313,67 @@ Deterministically generates new priv-key bytes from key.
 
 
 
-### <a name="PrivKeyEd25519.MarshalJSON">func</a> (PrivKeyEd25519) [MarshalJSON](/src/target/priv_key.go?s=2156:2209#L83)
+### <a name="PrivKeyEd25519.MarshalJSON">func</a> (PrivKeyEd25519) [MarshalJSON](/src/target/ed25519.go?s=1285:1338#L41)
 ``` go
 func (p PrivKeyEd25519) MarshalJSON() ([]byte, error)
 ```
 
 
 
-### <a name="PrivKeyEd25519.PubKey">func</a> (PrivKeyEd25519) [PubKey](/src/target/priv_key.go?s=1826:1871#L70)
+### <a name="PrivKeyEd25519.PubKey">func</a> (PrivKeyEd25519) [PubKey](/src/target/ed25519.go?s=917:962#L27)
 ``` go
 func (privKey PrivKeyEd25519) PubKey() PubKey
 ```
 
 
 
-### <a name="PrivKeyEd25519.Sign">func</a> (PrivKeyEd25519) [Sign](/src/target/priv_key.go?s=1635:1691#L64)
+### <a name="PrivKeyEd25519.Sign">func</a> (PrivKeyEd25519) [Sign](/src/target/ed25519.go?s=719:775#L21)
 ``` go
 func (privKey PrivKeyEd25519) Sign(msg []byte) Signature
 ```
 
 
 
-### <a name="PrivKeyEd25519.String">func</a> (PrivKeyEd25519) [String](/src/target/priv_key.go?s=2613:2658#L101)
+### <a name="PrivKeyEd25519.String">func</a> (PrivKeyEd25519) [String](/src/target/ed25519.go?s=1742:1787#L59)
 ``` go
 func (privKey PrivKeyEd25519) String() string
 ```
 
 
 
-### <a name="PrivKeyEd25519.ToCurve25519">func</a> (PrivKeyEd25519) [ToCurve25519](/src/target/priv_key.go?s=2399:2453#L94)
+### <a name="PrivKeyEd25519.ToCurve25519">func</a> (PrivKeyEd25519) [ToCurve25519](/src/target/ed25519.go?s=1528:1582#L52)
 ``` go
 func (privKey PrivKeyEd25519) ToCurve25519() *[32]byte
 ```
 
 
 
-### <a name="PrivKeyEd25519.UnmarshalJSON">func</a> (\*PrivKeyEd25519) [UnmarshalJSON](/src/target/priv_key.go?s=2250:2306#L87)
+### <a name="PrivKeyEd25519.UnmarshalJSON">func</a> (\*PrivKeyEd25519) [UnmarshalJSON](/src/target/ed25519.go?s=1379:1435#L45)
 ``` go
 func (p *PrivKeyEd25519) UnmarshalJSON(enc []byte) error
 ```
 
 
 
-## <a name="PrivKeyS">type</a> [PrivKeyS](/src/target/priv_key.go?s=929:962#L30)
+### <a name="PrivKeyEd25519.Wrap">func</a> (PrivKeyEd25519) [Wrap](/src/target/ed25519.go?s=2136:2180#L74)
 ``` go
-type PrivKeyS struct {
-    PrivKey
+func (privKey PrivKeyEd25519) Wrap() PrivKey
+```
+
+
+
+## <a name="PrivKeyInner">type</a> [PrivKeyInner](/src/target/priv_key.go?s=447:585#L13)
+``` go
+type PrivKeyInner interface {
+    AssertIsPrivKeyInner()
+    Sign(msg []byte) Signature
+    PubKey() PubKey
+    Equals(PrivKey) bool
+    Wrap() PrivKey
 }
 ```
-PrivKeyS add json serialization to PrivKey
+DO NOT USE THIS INTERFACE.
+You probably want to use PubKey
 
 
 
@@ -328,28 +384,7 @@ PrivKeyS add json serialization to PrivKey
 
 
 
-### <a name="PrivKeyS.Empty">func</a> (PrivKeyS) [Empty](/src/target/priv_key.go?s=1241:1271#L46)
-``` go
-func (p PrivKeyS) Empty() bool
-```
-
-
-
-### <a name="PrivKeyS.MarshalJSON">func</a> (PrivKeyS) [MarshalJSON](/src/target/priv_key.go?s=964:1011#L34)
-``` go
-func (p PrivKeyS) MarshalJSON() ([]byte, error)
-```
-
-
-
-### <a name="PrivKeyS.UnmarshalJSON">func</a> (\*PrivKeyS) [UnmarshalJSON](/src/target/priv_key.go?s=1057:1114#L38)
-``` go
-func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error)
-```
-
-
-
-## <a name="PrivKeySecp256k1">type</a> [PrivKeySecp256k1](/src/target/priv_key.go?s=3635:3665#L136)
+## <a name="PrivKeySecp256k1">type</a> [PrivKeySecp256k1](/src/target/secp256k1.go?s=598:628#L16)
 ``` go
 type PrivKeySecp256k1 [32]byte
 ```
@@ -361,12 +396,12 @@ Implements PrivKey
 
 
 
-### <a name="GenPrivKeySecp256k1">func</a> [GenPrivKeySecp256k1](/src/target/priv_key.go?s=5071:5114#L194)
+### <a name="GenPrivKeySecp256k1">func</a> [GenPrivKeySecp256k1](/src/target/secp256k1.go?s=2105:2148#L76)
 ``` go
 func GenPrivKeySecp256k1() PrivKeySecp256k1
 ```
 
-### <a name="GenPrivKeySecp256k1FromSecret">func</a> [GenPrivKeySecp256k1FromSecret](/src/target/priv_key.go?s=5436:5502#L204)
+### <a name="GenPrivKeySecp256k1FromSecret">func</a> [GenPrivKeySecp256k1FromSecret](/src/target/secp256k1.go?s=2470:2536#L86)
 ``` go
 func GenPrivKeySecp256k1FromSecret(secret []byte) PrivKeySecp256k1
 ```
@@ -377,74 +412,75 @@ if it's derived from user input.
 
 
 
-### <a name="PrivKeySecp256k1.Bytes">func</a> (PrivKeySecp256k1) [Bytes](/src/target/priv_key.go?s=3667:3713#L138)
+### <a name="PrivKeySecp256k1.AssertIsPrivKeyInner">func</a> (PrivKeySecp256k1) [AssertIsPrivKeyInner](/src/target/secp256k1.go?s=630:684#L18)
 ``` go
-func (privKey PrivKeySecp256k1) Bytes() []byte
+func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner()
 ```
 
 
 
-### <a name="PrivKeySecp256k1.Equals">func</a> (PrivKeySecp256k1) [Equals](/src/target/priv_key.go?s=4235:4293#L158)
+### <a name="PrivKeySecp256k1.Equals">func</a> (PrivKeySecp256k1) [Equals](/src/target/secp256k1.go?s=1170:1228#L36)
 ``` go
 func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool
 ```
 
 
 
-### <a name="PrivKeySecp256k1.MarshalJSON">func</a> (PrivKeySecp256k1) [MarshalJSON](/src/target/priv_key.go?s=4426:4481#L166)
+### <a name="PrivKeySecp256k1.MarshalJSON">func</a> (PrivKeySecp256k1) [MarshalJSON](/src/target/secp256k1.go?s=1370:1425#L44)
 ``` go
 func (p PrivKeySecp256k1) MarshalJSON() ([]byte, error)
 ```
 
 
 
-### <a name="PrivKeySecp256k1.PubKey">func</a> (PrivKeySecp256k1) [PubKey](/src/target/priv_key.go?s=4032:4079#L151)
+### <a name="PrivKeySecp256k1.PubKey">func</a> (PrivKeySecp256k1) [PubKey](/src/target/secp256k1.go?s=960:1007#L29)
 ``` go
 func (privKey PrivKeySecp256k1) PubKey() PubKey
 ```
 
 
 
-### <a name="PrivKeySecp256k1.Sign">func</a> (PrivKeySecp256k1) [Sign](/src/target/priv_key.go?s=3772:3830#L142)
+### <a name="PrivKeySecp256k1.Sign">func</a> (PrivKeySecp256k1) [Sign](/src/target/secp256k1.go?s=689:747#L20)
 ``` go
 func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature
 ```
 
 
 
-### <a name="PrivKeySecp256k1.String">func</a> (PrivKeySecp256k1) [String](/src/target/priv_key.go?s=4673:4720#L177)
+### <a name="PrivKeySecp256k1.String">func</a> (PrivKeySecp256k1) [String](/src/target/secp256k1.go?s=1617:1664#L55)
 ``` go
 func (privKey PrivKeySecp256k1) String() string
 ```
 
 
 
-### <a name="PrivKeySecp256k1.UnmarshalJSON">func</a> (\*PrivKeySecp256k1) [UnmarshalJSON](/src/target/priv_key.go?s=4522:4580#L170)
+### <a name="PrivKeySecp256k1.UnmarshalJSON">func</a> (\*PrivKeySecp256k1) [UnmarshalJSON](/src/target/secp256k1.go?s=1466:1524#L48)
 ``` go
 func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error
 ```
 
 
 
-## <a name="PubKey">type</a> [PubKey](/src/target/pub_key.go?s=361:506#L7)
+### <a name="PrivKeySecp256k1.Wrap">func</a> (PrivKeySecp256k1) [Wrap](/src/target/secp256k1.go?s=1713:1759#L59)
 ``` go
-type PubKey interface {
-    Address() []byte
-    Bytes() []byte
-    KeyString() string
-    VerifyBytes(msg []byte, sig Signature) bool
-    Equals(PubKey) bool
+func (privKey PrivKeySecp256k1) Wrap() PrivKey
+```
+
+
+
+## <a name="PubKey">type</a> [PubKey](/src/target/pub_key.go?s=274:325#L5)
+``` go
+type PubKey struct {
+    PubKeyInner `json:"unwrap"`
 }
 ```
-PubKey is part of Account and Validator.
 
 
 
 
 
 
-
-### <a name="PubKeyFromBytes">func</a> [PubKeyFromBytes](/src/target/pub_key.go?s=1203:1270#L45)
+### <a name="PubKeyFromBytes">func</a> [PubKeyFromBytes](/src/target/pub_key.go?s=99:166#L1)
 ``` go
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error)
 ```
@@ -452,11 +488,48 @@ func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error)
 
 
 
-## <a name="PubKeyEd25519">type</a> [PubKeyEd25519](/src/target/pub_key.go?s=1396:1423#L53)
+### <a name="PubKey.Bytes">func</a> (PubKey) [Bytes](/src/target/pub_key.go?s=611:641#L22)
+``` go
+func (p PubKey) Bytes() []byte
+```
+
+
+
+### <a name="PubKey.Empty">func</a> (PubKey) [Empty](/src/target/pub_key.go?s=1211:1239#L47)
+``` go
+func (p PubKey) Empty() bool
+```
+
+
+
+### <a name="PubKey.MarshalJSON">func</a> (PubKey) [MarshalJSON](/src/target/pub_key.go?s=675:721#L26)
+``` go
+func (pk PubKey) MarshalJSON() ([]byte, error)
+```
+
+
+
+### <a name="PubKey.UnmarshalJSON">func</a> (\*PubKey) [UnmarshalJSON](/src/target/pub_key.go?s=771:827#L30)
+``` go
+func (pk *PubKey) UnmarshalJSON(data []byte) (err error)
+```
+
+
+
+### <a name="PubKey.Unwrap">func</a> (PubKey) [Unwrap](/src/target/pub_key.go?s=1044:1081#L39)
+``` go
+func (pk PubKey) Unwrap() PubKeyInner
+```
+Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+
+
+
+
+## <a name="PubKeyEd25519">type</a> [PubKeyEd25519](/src/target/ed25519.go?s=2884:2911#L100)
 ``` go
 type PubKeyEd25519 [32]byte
 ```
-Implements PubKey
+Implements PubKeyInner
 
 
 
@@ -467,28 +540,28 @@ Implements PubKey
 
 
 
-### <a name="PubKeyEd25519.Address">func</a> (PubKeyEd25519) [Address](/src/target/pub_key.go?s=1425:1469#L55)
+### <a name="PubKeyEd25519.Address">func</a> (PubKeyEd25519) [Address](/src/target/ed25519.go?s=2967:3011#L104)
 ``` go
 func (pubKey PubKeyEd25519) Address() []byte
 ```
 
 
 
-### <a name="PubKeyEd25519.Bytes">func</a> (PubKeyEd25519) [Bytes](/src/target/pub_key.go?s=1789:1831#L68)
+### <a name="PubKeyEd25519.AssertIsPubKeyInner">func</a> (PubKeyEd25519) [AssertIsPubKeyInner](/src/target/ed25519.go?s=2913:2962#L102)
 ``` go
-func (pubKey PubKeyEd25519) Bytes() []byte
+func (pubKey PubKeyEd25519) AssertIsPubKeyInner()
 ```
 
 
 
-### <a name="PubKeyEd25519.Equals">func</a> (PubKeyEd25519) [Equals](/src/target/pub_key.go?s=3064:3117#L119)
+### <a name="PubKeyEd25519.Equals">func</a> (PubKeyEd25519) [Equals](/src/target/ed25519.go?s=4440:4493#L160)
 ``` go
 func (pubKey PubKeyEd25519) Equals(other PubKey) bool
 ```
 
 
 
-### <a name="PubKeyEd25519.KeyString">func</a> (PubKeyEd25519) [KeyString](/src/target/pub_key.go?s=2983:3029#L115)
+### <a name="PubKeyEd25519.KeyString">func</a> (PubKeyEd25519) [KeyString](/src/target/ed25519.go?s=4355:4401#L156)
 ``` go
 func (pubKey PubKeyEd25519) KeyString() string
 ```
@@ -498,21 +571,21 @@ Used for map keying, etc.
 
 
 
-### <a name="PubKeyEd25519.MarshalJSON">func</a> (PubKeyEd25519) [MarshalJSON](/src/target/pub_key.go?s=2279:2331#L87)
+### <a name="PubKeyEd25519.MarshalJSON">func</a> (PubKeyEd25519) [MarshalJSON](/src/target/ed25519.go?s=3647:3699#L128)
 ``` go
 func (p PubKeyEd25519) MarshalJSON() ([]byte, error)
 ```
 
 
 
-### <a name="PubKeyEd25519.String">func</a> (PubKeyEd25519) [String](/src/target/pub_key.go?s=2823:2866#L109)
+### <a name="PubKeyEd25519.String">func</a> (PubKeyEd25519) [String](/src/target/ed25519.go?s=4191:4234#L150)
 ``` go
 func (pubKey PubKeyEd25519) String() string
 ```
 
 
 
-### <a name="PubKeyEd25519.ToCurve25519">func</a> (PubKeyEd25519) [ToCurve25519](/src/target/pub_key.go?s=2585:2637#L100)
+### <a name="PubKeyEd25519.ToCurve25519">func</a> (PubKeyEd25519) [ToCurve25519](/src/target/ed25519.go?s=3953:4005#L141)
 ``` go
 func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte
 ```
@@ -522,27 +595,40 @@ If error, returns nil.
 
 
 
-### <a name="PubKeyEd25519.UnmarshalJSON">func</a> (\*PubKeyEd25519) [UnmarshalJSON](/src/target/pub_key.go?s=2372:2427#L91)
+### <a name="PubKeyEd25519.UnmarshalJSON">func</a> (\*PubKeyEd25519) [UnmarshalJSON](/src/target/ed25519.go?s=3740:3795#L132)
 ``` go
 func (p *PubKeyEd25519) UnmarshalJSON(enc []byte) error
 ```
 
 
 
-### <a name="PubKeyEd25519.VerifyBytes">func</a> (PubKeyEd25519) [VerifyBytes](/src/target/pub_key.go?s=1888:1960#L72)
+### <a name="PubKeyEd25519.VerifyBytes">func</a> (PubKeyEd25519) [VerifyBytes](/src/target/ed25519.go?s=3335:3407#L117)
 ``` go
 func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool
 ```
 
 
 
-## <a name="PubKeyS">type</a> [PubKeyS](/src/target/pub_key.go?s=841:872#L25)
+### <a name="PubKeyEd25519.Wrap">func</a> (PubKeyEd25519) [Wrap](/src/target/ed25519.go?s=4627:4668#L168)
 ``` go
-type PubKeyS struct {
-    PubKey
+func (pubKey PubKeyEd25519) Wrap() PubKey
+```
+
+
+
+## <a name="PubKeyInner">type</a> [PubKeyInner](/src/target/pub_key.go?s=437:609#L13)
+``` go
+type PubKeyInner interface {
+    AssertIsPubKeyInner()
+    Address() []byte
+    KeyString() string
+    VerifyBytes(msg []byte, sig Signature) bool
+    Equals(PubKey) bool
+    Wrap() PubKey
 }
 ```
-PubKeyS add json serialization to PubKey
+DO NOT USE THIS INTERFACE.
+You probably want to use PubKey
 
 
 
@@ -553,28 +639,7 @@ PubKeyS add json serialization to PubKey
 
 
 
-### <a name="PubKeyS.Empty">func</a> (PubKeyS) [Empty](/src/target/pub_key.go?s=1144:1173#L41)
-``` go
-func (p PubKeyS) Empty() bool
-```
-
-
-
-### <a name="PubKeyS.MarshalJSON">func</a> (PubKeyS) [MarshalJSON](/src/target/pub_key.go?s=874:920#L29)
-``` go
-func (p PubKeyS) MarshalJSON() ([]byte, error)
-```
-
-
-
-### <a name="PubKeyS.UnmarshalJSON">func</a> (\*PubKeyS) [UnmarshalJSON](/src/target/pub_key.go?s=964:1020#L33)
-``` go
-func (p *PubKeyS) UnmarshalJSON(data []byte) (err error)
-```
-
-
-
-## <a name="PubKeySecp256k1">type</a> [PubKeySecp256k1](/src/target/pub_key.go?s=3401:3430#L132)
+## <a name="PubKeySecp256k1">type</a> [PubKeySecp256k1](/src/target/secp256k1.go?s=2988:3017#L101)
 ``` go
 type PubKeySecp256k1 [33]byte
 ```
@@ -591,7 +656,7 @@ prefixed with 0x02 or 0x03, depending on the y-cord.
 
 
 
-### <a name="PubKeySecp256k1.Address">func</a> (PubKeySecp256k1) [Address](/src/target/pub_key.go?s=3497:3543#L135)
+### <a name="PubKeySecp256k1.Address">func</a> (PubKeySecp256k1) [Address](/src/target/secp256k1.go?s=3140:3186#L106)
 ``` go
 func (pubKey PubKeySecp256k1) Address() []byte
 ```
@@ -600,21 +665,21 @@ Implements Bitcoin style addresses: RIPEMD160(SHA256(pubkey))
 
 
 
-### <a name="PubKeySecp256k1.Bytes">func</a> (PubKeySecp256k1) [Bytes](/src/target/pub_key.go?s=3774:3818#L145)
+### <a name="PubKeySecp256k1.AssertIsPubKeyInner">func</a> (PubKeySecp256k1) [AssertIsPubKeyInner](/src/target/secp256k1.go?s=3019:3070#L103)
 ``` go
-func (pubKey PubKeySecp256k1) Bytes() []byte
+func (pubKey PubKeySecp256k1) AssertIsPubKeyInner()
 ```
 
 
 
-### <a name="PubKeySecp256k1.Equals">func</a> (PubKeySecp256k1) [Equals](/src/target/pub_key.go?s=4897:4952#L192)
+### <a name="PubKeySecp256k1.Equals">func</a> (PubKeySecp256k1) [Equals](/src/target/secp256k1.go?s=4368:4423#L155)
 ``` go
 func (pubKey PubKeySecp256k1) Equals(other PubKey) bool
 ```
 
 
 
-### <a name="PubKeySecp256k1.KeyString">func</a> (PubKeySecp256k1) [KeyString](/src/target/pub_key.go?s=4814:4862#L188)
+### <a name="PubKeySecp256k1.KeyString">func</a> (PubKeySecp256k1) [KeyString](/src/target/secp256k1.go?s=4281:4329#L151)
 ``` go
 func (pubKey PubKeySecp256k1) KeyString() string
 ```
@@ -624,52 +689,54 @@ Used for map keying, etc.
 
 
 
-### <a name="PubKeySecp256k1.MarshalJSON">func</a> (PubKeySecp256k1) [MarshalJSON](/src/target/pub_key.go?s=4405:4459#L171)
+### <a name="PubKeySecp256k1.MarshalJSON">func</a> (PubKeySecp256k1) [MarshalJSON](/src/target/secp256k1.go?s=3868:3922#L134)
 ``` go
 func (p PubKeySecp256k1) MarshalJSON() ([]byte, error)
 ```
 
 
 
-### <a name="PubKeySecp256k1.String">func</a> (PubKeySecp256k1) [String](/src/target/pub_key.go?s=4650:4695#L182)
+### <a name="PubKeySecp256k1.String">func</a> (PubKeySecp256k1) [String](/src/target/secp256k1.go?s=4113:4158#L145)
 ``` go
 func (pubKey PubKeySecp256k1) String() string
 ```
 
 
 
-### <a name="PubKeySecp256k1.UnmarshalJSON">func</a> (\*PubKeySecp256k1) [UnmarshalJSON](/src/target/pub_key.go?s=4500:4557#L175)
+### <a name="PubKeySecp256k1.UnmarshalJSON">func</a> (\*PubKeySecp256k1) [UnmarshalJSON](/src/target/secp256k1.go?s=3963:4020#L138)
 ``` go
 func (p *PubKeySecp256k1) UnmarshalJSON(enc []byte) error
 ```
 
 
 
-### <a name="PubKeySecp256k1.VerifyBytes">func</a> (PubKeySecp256k1) [VerifyBytes](/src/target/pub_key.go?s=3875:3949#L149)
+### <a name="PubKeySecp256k1.VerifyBytes">func</a> (PubKeySecp256k1) [VerifyBytes](/src/target/secp256k1.go?s=3417:3491#L116)
 ``` go
 func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool
 ```
 
 
 
-## <a name="Signature">type</a> [Signature](/src/target/signature.go?s=204:304#L3)
+### <a name="PubKeySecp256k1.Wrap">func</a> (PubKeySecp256k1) [Wrap](/src/target/secp256k1.go?s=4563:4606#L163)
 ``` go
-type Signature interface {
-    Bytes() []byte
-    IsZero() bool
-    String() string
-    Equals(Signature) bool
+func (pubKey PubKeySecp256k1) Wrap() PubKey
+```
+
+
+
+## <a name="Signature">type</a> [Signature](/src/target/signature.go?s=268:325#L5)
+``` go
+type Signature struct {
+    SignatureInner `json:"unwrap"`
 }
 ```
-Signature is a part of Txs and consensus Votes.
 
 
 
 
 
 
-
-### <a name="SignatureFromBytes">func</a> [SignatureFromBytes](/src/target/signature.go?s=1031:1098#L40)
+### <a name="SignatureFromBytes">func</a> [SignatureFromBytes](/src/target/signature.go?s=99:166#L1)
 ``` go
 func SignatureFromBytes(sigBytes []byte) (sig Signature, err error)
 ```
@@ -677,7 +744,44 @@ func SignatureFromBytes(sigBytes []byte) (sig Signature, err error)
 
 
 
-## <a name="SignatureEd25519">type</a> [SignatureEd25519](/src/target/signature.go?s=1221:1251#L48)
+### <a name="Signature.Bytes">func</a> (Signature) [Bytes](/src/target/signature.go?s=576:609#L21)
+``` go
+func (s Signature) Bytes() []byte
+```
+
+
+
+### <a name="Signature.Empty">func</a> (Signature) [Empty](/src/target/signature.go?s=1207:1240#L46)
+``` go
+func (sig Signature) Empty() bool
+```
+
+
+
+### <a name="Signature.MarshalJSON">func</a> (Signature) [MarshalJSON](/src/target/signature.go?s=643:693#L25)
+``` go
+func (sig Signature) MarshalJSON() ([]byte, error)
+```
+
+
+
+### <a name="Signature.UnmarshalJSON">func</a> (\*Signature) [UnmarshalJSON](/src/target/signature.go?s=744:804#L29)
+``` go
+func (sig *Signature) UnmarshalJSON(data []byte) (err error)
+```
+
+
+
+### <a name="Signature.Unwrap">func</a> (Signature) [Unwrap](/src/target/signature.go?s=1025:1069#L38)
+``` go
+func (sig Signature) Unwrap() SignatureInner
+```
+Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+
+
+
+
+## <a name="SignatureEd25519">type</a> [SignatureEd25519](/src/target/ed25519.go?s=4805:4835#L177)
 ``` go
 type SignatureEd25519 [64]byte
 ```
@@ -692,55 +796,67 @@ Implements Signature
 
 
 
-### <a name="SignatureEd25519.Bytes">func</a> (SignatureEd25519) [Bytes](/src/target/signature.go?s=1253:1295#L50)
+### <a name="SignatureEd25519.AssertIsSignatureInner">func</a> (SignatureEd25519) [AssertIsSignatureInner](/src/target/ed25519.go?s=4837:4889#L179)
 ``` go
-func (sig SignatureEd25519) Bytes() []byte
+func (sig SignatureEd25519) AssertIsSignatureInner()
 ```
 
 
 
-### <a name="SignatureEd25519.Equals">func</a> (SignatureEd25519) [Equals](/src/target/signature.go?s=1520:1576#L58)
+### <a name="SignatureEd25519.Equals">func</a> (SignatureEd25519) [Equals](/src/target/ed25519.go?s=5066:5122#L185)
 ``` go
 func (sig SignatureEd25519) Equals(other Signature) bool
 ```
 
 
 
-### <a name="SignatureEd25519.IsZero">func</a> (SignatureEd25519) [IsZero](/src/target/signature.go?s=1352:1393#L54)
+### <a name="SignatureEd25519.IsZero">func</a> (SignatureEd25519) [IsZero](/src/target/ed25519.go?s=4894:4935#L181)
 ``` go
 func (sig SignatureEd25519) IsZero() bool
 ```
 
 
 
-### <a name="SignatureEd25519.MarshalJSON">func</a> (SignatureEd25519) [MarshalJSON](/src/target/signature.go?s=1701:1756#L66)
+### <a name="SignatureEd25519.MarshalJSON">func</a> (SignatureEd25519) [MarshalJSON](/src/target/ed25519.go?s=5256:5313#L193)
 ``` go
-func (p SignatureEd25519) MarshalJSON() ([]byte, error)
+func (sig SignatureEd25519) MarshalJSON() ([]byte, error)
 ```
 
 
 
-### <a name="SignatureEd25519.String">func</a> (SignatureEd25519) [String](/src/target/signature.go?s=1420:1463#L56)
+### <a name="SignatureEd25519.String">func</a> (SignatureEd25519) [String](/src/target/ed25519.go?s=4962:5005#L183)
 ``` go
 func (sig SignatureEd25519) String() string
 ```
 
 
 
-### <a name="SignatureEd25519.UnmarshalJSON">func</a> (\*SignatureEd25519) [UnmarshalJSON](/src/target/signature.go?s=1797:1855#L70)
+### <a name="SignatureEd25519.UnmarshalJSON">func</a> (\*SignatureEd25519) [UnmarshalJSON](/src/target/ed25519.go?s=5356:5416#L197)
 ``` go
-func (p *SignatureEd25519) UnmarshalJSON(enc []byte) error
+func (sig *SignatureEd25519) UnmarshalJSON(enc []byte) error
 ```
 
 
 
-## <a name="SignatureS">type</a> [SignatureS](/src/target/signature.go?s=648:685#L20)
+### <a name="SignatureEd25519.Wrap">func</a> (SignatureEd25519) [Wrap](/src/target/ed25519.go?s=5511:5555#L204)
 ``` go
-type SignatureS struct {
-    Signature
+func (sig SignatureEd25519) Wrap() Signature
+```
+
+
+
+## <a name="SignatureInner">type</a> [SignatureInner](/src/target/signature.go?s=441:574#L13)
+``` go
+type SignatureInner interface {
+    AssertIsSignatureInner()
+    IsZero() bool
+    String() string
+    Equals(Signature) bool
+    Wrap() Signature
 }
 ```
-SignatureS add json serialization to Signature
+DO NOT USE THIS INTERFACE.
+You probably want to use Signature.
 
 
 
@@ -751,28 +867,7 @@ SignatureS add json serialization to Signature
 
 
 
-### <a name="SignatureS.Empty">func</a> (SignatureS) [Empty](/src/target/signature.go?s=966:998#L36)
-``` go
-func (p SignatureS) Empty() bool
-```
-
-
-
-### <a name="SignatureS.MarshalJSON">func</a> (SignatureS) [MarshalJSON](/src/target/signature.go?s=687:736#L24)
-``` go
-func (p SignatureS) MarshalJSON() ([]byte, error)
-```
-
-
-
-### <a name="SignatureS.UnmarshalJSON">func</a> (\*SignatureS) [UnmarshalJSON](/src/target/signature.go?s=780:839#L28)
-``` go
-func (p *SignatureS) UnmarshalJSON(data []byte) (err error)
-```
-
-
-
-## <a name="SignatureSecp256k1">type</a> [SignatureSecp256k1](/src/target/signature.go?s=2013:2043#L80)
+## <a name="SignatureSecp256k1">type</a> [SignatureSecp256k1](/src/target/secp256k1.go?s=4745:4775#L172)
 ``` go
 type SignatureSecp256k1 []byte
 ```
@@ -787,44 +882,51 @@ Implements Signature
 
 
 
-### <a name="SignatureSecp256k1.Bytes">func</a> (SignatureSecp256k1) [Bytes](/src/target/signature.go?s=2045:2089#L82)
+### <a name="SignatureSecp256k1.AssertIsSignatureInner">func</a> (SignatureSecp256k1) [AssertIsSignatureInner](/src/target/secp256k1.go?s=4777:4831#L174)
 ``` go
-func (sig SignatureSecp256k1) Bytes() []byte
+func (sig SignatureSecp256k1) AssertIsSignatureInner()
 ```
 
 
 
-### <a name="SignatureSecp256k1.Equals">func</a> (SignatureSecp256k1) [Equals](/src/target/signature.go?s=2318:2376#L90)
+### <a name="SignatureSecp256k1.Equals">func</a> (SignatureSecp256k1) [Equals](/src/target/secp256k1.go?s=5012:5070#L180)
 ``` go
 func (sig SignatureSecp256k1) Equals(other Signature) bool
 ```
 
 
 
-### <a name="SignatureSecp256k1.IsZero">func</a> (SignatureSecp256k1) [IsZero](/src/target/signature.go?s=2146:2189#L86)
+### <a name="SignatureSecp256k1.IsZero">func</a> (SignatureSecp256k1) [IsZero](/src/target/secp256k1.go?s=4836:4879#L176)
 ``` go
 func (sig SignatureSecp256k1) IsZero() bool
 ```
 
 
 
-### <a name="SignatureSecp256k1.MarshalJSON">func</a> (SignatureSecp256k1) [MarshalJSON](/src/target/signature.go?s=2502:2559#L97)
+### <a name="SignatureSecp256k1.MarshalJSON">func</a> (SignatureSecp256k1) [MarshalJSON](/src/target/secp256k1.go?s=5205:5264#L187)
 ``` go
-func (p SignatureSecp256k1) MarshalJSON() ([]byte, error)
+func (sig SignatureSecp256k1) MarshalJSON() ([]byte, error)
 ```
 
 
 
-### <a name="SignatureSecp256k1.String">func</a> (SignatureSecp256k1) [String](/src/target/signature.go?s=2216:2261#L88)
+### <a name="SignatureSecp256k1.String">func</a> (SignatureSecp256k1) [String](/src/target/secp256k1.go?s=4906:4951#L178)
 ``` go
 func (sig SignatureSecp256k1) String() string
 ```
 
 
 
-### <a name="SignatureSecp256k1.UnmarshalJSON">func</a> (\*SignatureSecp256k1) [UnmarshalJSON](/src/target/signature.go?s=2597:2657#L101)
+### <a name="SignatureSecp256k1.UnmarshalJSON">func</a> (\*SignatureSecp256k1) [UnmarshalJSON](/src/target/secp256k1.go?s=5304:5366#L191)
 ``` go
-func (p *SignatureSecp256k1) UnmarshalJSON(enc []byte) error
+func (sig *SignatureSecp256k1) UnmarshalJSON(enc []byte) error
+```
+
+
+
+### <a name="SignatureSecp256k1.Wrap">func</a> (SignatureSecp256k1) [Wrap](/src/target/secp256k1.go?s=5424:5470#L195)
+``` go
+func (sig SignatureSecp256k1) Wrap() Signature
 ```
 
 

--- a/crypto.go
+++ b/crypto.go
@@ -1,0 +1,9 @@
+package crypto
+
+// Types of implementations
+const (
+	TypeEd25519   = byte(0x01)
+	TypeSecp256k1 = byte(0x02)
+	NameEd25519   = "ed25519"
+	NameSecp256k1 = "secp256k1"
+)

--- a/ed25519.go
+++ b/ed25519.go
@@ -1,0 +1,228 @@
+package crypto
+
+import (
+	"bytes"
+	"fmt"
+
+	"golang.org/x/crypto/ripemd160"
+
+	"github.com/tendermint/ed25519"
+	"github.com/tendermint/ed25519/extra25519"
+	cmn "github.com/tendermint/go-common"
+	data "github.com/tendermint/go-data"
+	wire "github.com/tendermint/go-wire"
+)
+
+func init() {
+	privKeyMapper.RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519)
+	pubKeyMapper.RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519)
+	sigMapper.RegisterImplementation(SignatureEd25519{}, NameEd25519, TypeEd25519)
+}
+
+//-------------------------------------
+
+var _ PrivKeyInner = PrivKeyEd25519{}
+
+// Implements PrivKey
+type PrivKeyEd25519 [64]byte
+
+func (privKey PrivKeyEd25519) AssertIsPrivKeyInner() {}
+
+func (privKey PrivKeyEd25519) Bytes() []byte {
+	return wire.BinaryBytes(PrivKey{privKey})
+}
+
+func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
+	privKeyBytes := [64]byte(privKey)
+	signatureBytes := ed25519.Sign(&privKeyBytes, msg)
+	return SignatureEd25519(*signatureBytes).Wrap()
+}
+
+func (privKey PrivKeyEd25519) PubKey() PubKey {
+	privKeyBytes := [64]byte(privKey)
+	pubBytes := *ed25519.MakePublicKey(&privKeyBytes)
+	return PubKeyEd25519(pubBytes).Wrap()
+}
+
+func (privKey PrivKeyEd25519) Equals(other PrivKey) bool {
+	if otherEd, ok := other.Unwrap().(PrivKeyEd25519); ok {
+		return bytes.Equal(privKey[:], otherEd[:])
+	} else {
+		return false
+	}
+}
+
+func (p PrivKeyEd25519) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p[:])
+}
+
+func (p *PrivKeyEd25519) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(p[:], ref)
+	return err
+}
+
+func (privKey PrivKeyEd25519) ToCurve25519() *[32]byte {
+	keyCurve25519 := new([32]byte)
+	privKeyBytes := [64]byte(privKey)
+	extra25519.PrivateKeyToCurve25519(keyCurve25519, &privKeyBytes)
+	return keyCurve25519
+}
+
+func (privKey PrivKeyEd25519) String() string {
+	return cmn.Fmt("PrivKeyEd25519{*****}")
+}
+
+// Deterministically generates new priv-key bytes from key.
+func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519 {
+	newBytes := wire.BinarySha256(struct {
+		PrivKey [64]byte
+		Index   int
+	}{privKey, index})
+	var newKey [64]byte
+	copy(newKey[:], newBytes)
+	return PrivKeyEd25519(newKey)
+}
+
+func (privKey PrivKeyEd25519) Wrap() PrivKey {
+	return PrivKey{privKey}
+}
+
+func GenPrivKeyEd25519() PrivKeyEd25519 {
+	privKeyBytes := new([64]byte)
+	copy(privKeyBytes[:32], CRandBytes(32))
+	ed25519.MakePublicKey(privKeyBytes)
+	return PrivKeyEd25519(*privKeyBytes)
+}
+
+// NOTE: secret should be the output of a KDF like bcrypt,
+// if it's derived from user input.
+func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519 {
+	privKey32 := Sha256(secret) // Not Ripemd160 because we want 32 bytes.
+	privKeyBytes := new([64]byte)
+	copy(privKeyBytes[:32], privKey32)
+	ed25519.MakePublicKey(privKeyBytes)
+	return PrivKeyEd25519(*privKeyBytes)
+}
+
+//-------------------------------------
+
+var _ PubKeyInner = PubKeyEd25519{}
+
+// Implements PubKeyInner
+type PubKeyEd25519 [32]byte
+
+func (pubKey PubKeyEd25519) AssertIsPubKeyInner() {}
+
+func (pubKey PubKeyEd25519) Address() []byte {
+	w, n, err := new(bytes.Buffer), new(int), new(error)
+	wire.WriteBinary(pubKey[:], w, n, err)
+	if *err != nil {
+		cmn.PanicCrisis(*err)
+	}
+	// append type byte
+	encodedPubkey := append([]byte{TypeEd25519}, w.Bytes()...)
+	hasher := ripemd160.New()
+	hasher.Write(encodedPubkey) // does not error
+	return hasher.Sum(nil)
+}
+
+func (pubKey PubKeyEd25519) Bytes() []byte {
+	return wire.BinaryBytes(PubKey{pubKey})
+}
+
+func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
+	// make sure we use the same algorithm to sign
+	sig, ok := sig_.Unwrap().(SignatureEd25519)
+	if !ok {
+		return false
+	}
+	pubKeyBytes := [32]byte(pubKey)
+	sigBytes := [64]byte(sig)
+	return ed25519.Verify(&pubKeyBytes, msg, &sigBytes)
+}
+
+func (p PubKeyEd25519) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p[:])
+}
+
+func (p *PubKeyEd25519) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(p[:], ref)
+	return err
+}
+
+// For use with golang/crypto/nacl/box
+// If error, returns nil.
+func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte {
+	keyCurve25519, pubKeyBytes := new([32]byte), [32]byte(pubKey)
+	ok := extra25519.PublicKeyToCurve25519(keyCurve25519, &pubKeyBytes)
+	if !ok {
+		return nil
+	}
+	return keyCurve25519
+}
+
+func (pubKey PubKeyEd25519) String() string {
+	return cmn.Fmt("PubKeyEd25519{%X}", pubKey[:])
+}
+
+// Must return the full bytes in hex.
+// Used for map keying, etc.
+func (pubKey PubKeyEd25519) KeyString() string {
+	return cmn.Fmt("%X", pubKey[:])
+}
+
+func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
+	if otherEd, ok := other.Unwrap().(PubKeyEd25519); ok {
+		return bytes.Equal(pubKey[:], otherEd[:])
+	} else {
+		return false
+	}
+}
+
+func (pubKey PubKeyEd25519) Wrap() PubKey {
+	return PubKey{pubKey}
+}
+
+//-------------------------------------
+
+var _ SignatureInner = SignatureEd25519{}
+
+// Implements Signature
+type SignatureEd25519 [64]byte
+
+func (sig SignatureEd25519) AssertIsSignatureInner() {}
+
+func (sig SignatureEd25519) Bytes() []byte {
+	return wire.BinaryBytes(Signature{sig})
+}
+
+func (sig SignatureEd25519) IsZero() bool { return len(sig) == 0 }
+
+func (sig SignatureEd25519) String() string { return fmt.Sprintf("/%X.../", cmn.Fingerprint(sig[:])) }
+
+func (sig SignatureEd25519) Equals(other Signature) bool {
+	if otherEd, ok := other.Unwrap().(SignatureEd25519); ok {
+		return bytes.Equal(sig[:], otherEd[:])
+	} else {
+		return false
+	}
+}
+
+func (sig SignatureEd25519) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(sig[:])
+}
+
+func (sig *SignatureEd25519) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(sig[:], ref)
+	return err
+}
+
+func (sig SignatureEd25519) Wrap() Signature {
+	return Signature{sig}
+}

--- a/ed25519.go
+++ b/ed25519.go
@@ -28,10 +28,6 @@ type PrivKeyEd25519 [64]byte
 
 func (privKey PrivKeyEd25519) AssertIsPrivKeyInner() {}
 
-func (privKey PrivKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(PrivKey{privKey})
-}
-
 func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
 	privKeyBytes := [64]byte(privKey)
 	signatureBytes := ed25519.Sign(&privKeyBytes, msg)
@@ -128,10 +124,6 @@ func (pubKey PubKeyEd25519) Address() []byte {
 	return hasher.Sum(nil)
 }
 
-func (pubKey PubKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(PubKey{pubKey})
-}
-
 func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
 	// make sure we use the same algorithm to sign
 	sig, ok := sig_.Unwrap().(SignatureEd25519)
@@ -195,10 +187,6 @@ var _ SignatureInner = SignatureEd25519{}
 type SignatureEd25519 [64]byte
 
 func (sig SignatureEd25519) AssertIsSignatureInner() {}
-
-func (sig SignatureEd25519) Bytes() []byte {
-	return wire.BinaryBytes(Signature{sig})
-}
 
 func (sig SignatureEd25519) IsZero() bool { return len(sig) == 0 }
 

--- a/embed_test.go
+++ b/embed_test.go
@@ -9,50 +9,13 @@ import (
 	data "github.com/tendermint/go-data"
 )
 
-type Foo struct {
-	Name string
-}
-
-func (f Foo) Greet() string {
-	return "Foo: " + f.Name
-}
-
-type Bar struct {
-	Age int
-}
-
-func (b Bar) Greet() string {
-	return fmt.Sprintf("Bar #%d", b.Age)
+type PubName struct {
+	PubNameInner
 }
 
 type PubNameInner interface {
-	Greet() string
-}
-
-type privNameInner interface {
-	Greet() string
-}
-
-type Greeter interface {
-	Greet() string
-}
-
-var (
-	pubNameMapper, privNameMapper data.Mapper
-)
-
-// register both public key types with go-data (and thus go-wire)
-func init() {
-	pubNameMapper = data.NewMapper(PubName{}).
-		RegisterImplementation(Foo{}, "foo", 1).
-		RegisterImplementation(Bar{}, "bar", 2)
-	privNameMapper = data.NewMapper(PrivName{}).
-		RegisterImplementation(Foo{}, "foo", 1).
-		RegisterImplementation(Bar{}, "bar", 2)
-}
-
-type PubName struct {
-	PubNameInner
+	AssertIsPubNameInner()
+	String() string
 }
 
 func (p PubName) MarshalJSON() ([]byte, error) {
@@ -67,62 +30,61 @@ func (p *PubName) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-type PrivName struct {
-	privNameInner
+var pubNameMapper = data.NewMapper(PubName{}).
+	RegisterImplementation(PubNameFoo{}, "foo", 1).
+	RegisterImplementation(PubNameBar{}, "bar", 2)
+
+func (f PubNameFoo) AssertIsPubNameInner() {}
+func (f PubNameBar) AssertIsPubNameInner() {}
+
+//----------------------------------------
+
+type PubNameFoo struct {
+	Name string
 }
 
-func (p PrivName) MarshalJSON() ([]byte, error) {
-	return privNameMapper.ToJSON(p.privNameInner)
+func (f PubNameFoo) String() string { return "Foo: " + f.Name }
+
+type PubNameBar struct {
+	Age int
 }
 
-func (p *PrivName) UnmarshalJSON(data []byte) error {
-	parsed, err := privNameMapper.FromJSON(data)
-	if err == nil && parsed != nil {
-		p.privNameInner = parsed.(privNameInner)
-	}
-	return err
-}
+func (b PubNameBar) String() string { return fmt.Sprintf("Bar #%d", b.Age) }
+
+//----------------------------------------
 
 // TestEncodeDemo tries the various strategies to encode the objects
 func TestEncodeDemo(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
-	// assert := assert.New(t)
-	// require := require.New(t)
 
 	cases := []struct {
-		in, out  Greeter
+		in, out  PubNameInner
 		expected string
 	}{
-		{PubName{Foo{"pub-foo"}}, &PubName{}, "Foo: pub-foo"},
-		{PubName{Bar{7}}, &PubName{}, "Bar #7"},
-
-		// Note these fail - if you can figure a solution here, I'll buy you a beer :)
-		// (ebuchman is right, you must either break the reflection system, or modify go-wire)
-		// but such a mod would let us make REALLY sure that no one could construct like this
-
-		// {PrivName{Foo{"priv-foo"}}, &PrivName{}, "Foo: priv-foo"},
-		// {PrivName{Bar{9}}, &PrivName{}, "Bar #9"},
+		{PubName{PubNameFoo{"pub-foo"}}, &PubName{}, "Foo: pub-foo"},
+		{PubName{PubNameBar{7}}, &PubName{}, "Bar #7"},
 	}
 
 	for i, tc := range cases {
-		// make sure it is proper to start
-		require.Equal(tc.expected, tc.in.Greet())
 
-		// now, try to encode as binary
+		// Make sure it is proper to start
+		require.Equal(tc.expected, tc.in.String())
+
+		// Try to encode as binary
 		b, err := data.ToWire(tc.in)
 		if assert.Nil(err, "%d: %#v", i, tc.in) {
 			err := data.FromWire(b, tc.out)
 			if assert.Nil(err) {
-				assert.Equal(tc.expected, tc.out.Greet())
+				assert.Equal(tc.expected, tc.out.String())
 			}
 		}
 
-		// try to encode it as json
+		// Try to encode it as json
 		j, err := data.ToJSON(tc.in)
 		if assert.Nil(err, "%d: %#v", i, tc.in) {
 			err := data.FromJSON(j, tc.out)
 			if assert.Nil(err) {
-				assert.Equal(tc.expected, tc.out.Greet())
+				assert.Equal(tc.expected, tc.out.String())
 			}
 		}
 	}

--- a/embed_test.go
+++ b/embed_test.go
@@ -103,7 +103,6 @@ func TestEncodeDemo(t *testing.T) {
 	for i, tc := range cases {
 		// make sure it is proper to start
 		require.Equal(tc.expected, tc.in.Greet())
-		fmt.Println(tc.expected)
 
 		// now, try to encode as binary
 		b, err := data.ToWire(tc.in)

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,126 @@
+package crypto_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	data "github.com/tendermint/go-data"
+)
+
+type Foo struct {
+	Name string
+}
+
+func (f Foo) Greet() string {
+	return "Foo: " + f.Name
+}
+
+type Bar struct {
+	Age int
+}
+
+func (b Bar) Greet() string {
+	return fmt.Sprintf("Bar #%d", b.Age)
+}
+
+type PubNameInner interface {
+	Greet() string
+}
+
+type privNameInner interface {
+	Greet() string
+}
+
+type Greeter interface {
+	Greet() string
+}
+
+var (
+	pubNameMapper, privNameMapper data.Mapper
+)
+
+// register both public key types with go-data (and thus go-wire)
+func init() {
+	pubNameMapper = data.NewMapper(PubName{}).
+		RegisterImplementation(Foo{}, "foo", 1).
+		RegisterImplementation(Bar{}, "bar", 2)
+	privNameMapper = data.NewMapper(PrivName{}).
+		RegisterImplementation(Foo{}, "foo", 1).
+		RegisterImplementation(Bar{}, "bar", 2)
+}
+
+type PubName struct {
+	PubNameInner
+}
+
+func (p PubName) MarshalJSON() ([]byte, error) {
+	return pubNameMapper.ToJSON(p.PubNameInner)
+}
+
+func (p *PubName) UnmarshalJSON(data []byte) error {
+	parsed, err := pubNameMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		p.PubNameInner = parsed.(PubNameInner)
+	}
+	return err
+}
+
+type PrivName struct {
+	privNameInner
+}
+
+func (p PrivName) MarshalJSON() ([]byte, error) {
+	return privNameMapper.ToJSON(p.privNameInner)
+}
+
+func (p *PrivName) UnmarshalJSON(data []byte) error {
+	parsed, err := privNameMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		p.privNameInner = parsed.(privNameInner)
+	}
+	return err
+}
+
+// TestEncodeDemo tries the various strategies to encode the objects
+func TestEncodeDemo(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	// assert := assert.New(t)
+	// require := require.New(t)
+
+	cases := []struct {
+		in, out  Greeter
+		expected string
+	}{
+		{PubName{Foo{"pub-foo"}}, &PubName{}, "Foo: pub-foo"},
+		{PubName{Bar{7}}, &PubName{}, "Bar #7"},
+		// Note these fail - if you can figure a solution here, I'll buy you a beer :)
+		// {PrivName{Foo{"priv-foo"}}, &PrivName{}, "Foo: priv-foo"},
+		// {PrivName{Bar{9}}, &PrivName{}, "Bar #9"},
+	}
+
+	for i, tc := range cases {
+		// make sure it is proper to start
+		require.Equal(tc.expected, tc.in.Greet())
+		fmt.Println(tc.expected)
+
+		// now, try to encode as binary
+		b, err := data.ToWire(tc.in)
+		if assert.Nil(err, "%d: %#v", i, tc.in) {
+			err := data.FromWire(b, tc.out)
+			if assert.Nil(err) {
+				assert.Equal(tc.expected, tc.out.Greet())
+			}
+		}
+
+		// try to encode it as json
+		j, err := data.ToJSON(tc.in)
+		if assert.Nil(err, "%d: %#v", i, tc.in) {
+			err := data.FromJSON(j, tc.out)
+			if assert.Nil(err) {
+				assert.Equal(tc.expected, tc.out.Greet())
+			}
+		}
+	}
+}

--- a/embed_test.go
+++ b/embed_test.go
@@ -95,7 +95,11 @@ func TestEncodeDemo(t *testing.T) {
 	}{
 		{PubName{Foo{"pub-foo"}}, &PubName{}, "Foo: pub-foo"},
 		{PubName{Bar{7}}, &PubName{}, "Bar #7"},
+
 		// Note these fail - if you can figure a solution here, I'll buy you a beer :)
+		// (ebuchman is right, you must either break the reflection system, or modify go-wire)
+		// but such a mod would let us make REALLY sure that no one could construct like this
+
 		// {PrivName{Foo{"priv-foo"}}, &PrivName{}, "Foo: priv-foo"},
 		// {PrivName{Bar{9}}, &PrivName{}, "Bar #9"},
 	}

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,91 @@
+package crypto_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	data "github.com/tendermint/go-data"
+)
+
+type PubName struct {
+	PubNameInner
+}
+
+type PubNameInner interface {
+	AssertIsPubNameInner()
+	String() string
+}
+
+func (p PubName) MarshalJSON() ([]byte, error) {
+	return pubNameMapper.ToJSON(p.PubNameInner)
+}
+
+func (p *PubName) UnmarshalJSON(data []byte) error {
+	parsed, err := pubNameMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		p.PubNameInner = parsed.(PubNameInner)
+	}
+	return err
+}
+
+var pubNameMapper = data.NewMapper(PubName{}).
+	RegisterImplementation(PubNameFoo{}, "foo", 1).
+	RegisterImplementation(PubNameBar{}, "bar", 2)
+
+func (f PubNameFoo) AssertIsPubNameInner() {}
+func (f PubNameBar) AssertIsPubNameInner() {}
+
+//----------------------------------------
+
+type PubNameFoo struct {
+	Name string
+}
+
+func (f PubNameFoo) String() string { return "Foo: " + f.Name }
+
+type PubNameBar struct {
+	Age int
+}
+
+func (b PubNameBar) String() string { return fmt.Sprintf("Bar #%d", b.Age) }
+
+//----------------------------------------
+
+// TestEncodeDemo tries the various strategies to encode the objects
+func TestEncodeDemo(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+
+	cases := []struct {
+		in, out  PubNameInner
+		expected string
+	}{
+		{PubName{PubNameFoo{"pub-foo"}}, &PubName{}, "Foo: pub-foo"},
+		{PubName{PubNameBar{7}}, &PubName{}, "Bar #7"},
+	}
+
+	for i, tc := range cases {
+
+		// Make sure it is proper to start
+		require.Equal(tc.expected, tc.in.String())
+
+		// Try to encode as binary
+		b, err := data.ToWire(tc.in)
+		if assert.Nil(err, "%d: %#v", i, tc.in) {
+			err := data.FromWire(b, tc.out)
+			if assert.Nil(err) {
+				assert.Equal(tc.expected, tc.out.String())
+			}
+		}
+
+		// Try to encode it as json
+		j, err := data.ToJSON(tc.in)
+		if assert.Nil(err, "%d: %#v", i, tc.in) {
+			err := data.FromJSON(j, tc.out)
+			if assert.Nil(err) {
+				assert.Equal(tc.expected, tc.out.String())
+			}
+		}
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -50,17 +50,17 @@ func checkJSON(t *testing.T, in interface{}, reader interface{}, typ string) {
 
 func TestKeyEncodings(t *testing.T) {
 	cases := []struct {
-		privKey PrivKeyS
+		privKey PrivKey
 		keyType byte
 		keyName string
 	}{
 		{
-			privKey: PrivKeyS{GenPrivKeyEd25519()},
+			privKey: WrapPrivKey(GenPrivKeyEd25519()),
 			keyType: TypeEd25519,
 			keyName: NameEd25519,
 		},
 		{
-			privKey: PrivKeyS{GenPrivKeySecp256k1()},
+			privKey: WrapPrivKey(GenPrivKeySecp256k1()),
 			keyType: TypeSecp256k1,
 			keyName: NameSecp256k1,
 		},
@@ -68,19 +68,19 @@ func TestKeyEncodings(t *testing.T) {
 
 	for _, tc := range cases {
 		// check (de/en)codings of private key
-		priv2 := PrivKeyS{}
+		priv2 := PrivKey{}
 		checkWire(t, tc.privKey, &priv2, tc.keyType)
 		assert.EqualValues(t, tc.privKey, priv2)
-		priv3 := PrivKeyS{}
+		priv3 := PrivKey{}
 		checkJSON(t, tc.privKey, &priv3, tc.keyName)
 		assert.EqualValues(t, tc.privKey, priv3)
 
 		// check (de/en)codings of public key
-		pubKey := PubKeyS{tc.privKey.PubKey()}
-		pub2 := PubKeyS{}
+		pubKey := tc.privKey.PubKey()
+		pub2 := PubKey{}
 		checkWire(t, pubKey, &pub2, tc.keyType)
 		assert.EqualValues(t, pubKey, pub2)
-		pub3 := PubKeyS{}
+		pub3 := PubKey{}
 		checkJSON(t, pubKey, &pub3, tc.keyName)
 		assert.EqualValues(t, pubKey, pub3)
 	}
@@ -95,17 +95,17 @@ func toFromJSON(t *testing.T, in interface{}, recvr interface{}) {
 
 func TestNilEncodings(t *testing.T) {
 	// make sure sigs are okay with nil
-	a, b := SignatureS{}, SignatureS{}
+	a, b := Signature{}, Signature{}
 	toFromJSON(t, a, &b)
 	assert.EqualValues(t, a, b)
 
 	// make sure sigs are okay with nil
-	c, d := PubKeyS{}, PubKeyS{}
+	c, d := PubKey{}, PubKey{}
 	toFromJSON(t, c, &d)
 	assert.EqualValues(t, c, d)
 
 	// make sure sigs are okay with nil
-	e, f := PrivKeyS{}, PrivKeyS{}
+	e, f := PrivKey{}, PrivKey{}
 	toFromJSON(t, e, &f)
 	assert.EqualValues(t, e, f)
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -69,12 +69,12 @@ func TestKeyEncodings(t *testing.T) {
 		keyName string
 	}{
 		{
-			privKey: WrapPrivKey(GenPrivKeyEd25519()),
+			privKey: GenPrivKeyEd25519().Wrap(),
 			keyType: TypeEd25519,
 			keyName: NameEd25519,
 		},
 		{
-			privKey: WrapPrivKey(GenPrivKeySecp256k1()),
+			privKey: GenPrivKeySecp256k1().Wrap(),
 			keyType: TypeSecp256k1,
 			keyName: NameSecp256k1,
 		},

--- a/encode_test.go
+++ b/encode_test.go
@@ -16,13 +16,15 @@ type byter interface {
 }
 
 // go to wire encoding and back
-func checkWire(t *testing.T, in byter, reader interface{}, typ byte) {
+func checkWire(t *testing.T, in byter, reader interface{}, typ byte, size int) {
 	// test to and from binary
 	bin, err := data.ToWire(in)
 	require.Nil(t, err, "%+v", err)
 	assert.Equal(t, typ, bin[0])
 	// make sure this is compatible with current (Bytes()) encoding
 	assert.Equal(t, in.Bytes(), bin)
+	// make sure we have the expected length
+	assert.Equal(t, size, len(bin))
 
 	err = data.FromWire(bin, reader)
 	require.Nil(t, err, "%+v", err)
@@ -67,23 +69,29 @@ func TestKeyEncodings(t *testing.T) {
 		privKey PrivKey
 		keyType byte
 		keyName string
+		// 1 (type byte) + size of byte array
+		privSize, pubSize int
 	}{
 		{
-			privKey: GenPrivKeyEd25519().Wrap(),
-			keyType: TypeEd25519,
-			keyName: NameEd25519,
+			privKey:  GenPrivKeyEd25519().Wrap(),
+			keyType:  TypeEd25519,
+			keyName:  NameEd25519,
+			privSize: 65,
+			pubSize:  33,
 		},
 		{
-			privKey: GenPrivKeySecp256k1().Wrap(),
-			keyType: TypeSecp256k1,
-			keyName: NameSecp256k1,
+			privKey:  GenPrivKeySecp256k1().Wrap(),
+			keyType:  TypeSecp256k1,
+			keyName:  NameSecp256k1,
+			privSize: 33,
+			pubSize:  34,
 		},
 	}
 
 	for _, tc := range cases {
 		// check (de/en)codings of private key
 		var priv2, priv3, priv4 PrivKey
-		checkWire(t, tc.privKey, &priv2, tc.keyType)
+		checkWire(t, tc.privKey, &priv2, tc.keyType, tc.privSize)
 		assert.EqualValues(t, tc.privKey, priv2)
 		checkJSON(t, tc.privKey, &priv3, tc.keyName)
 		assert.EqualValues(t, tc.privKey, priv3)
@@ -93,7 +101,7 @@ func TestKeyEncodings(t *testing.T) {
 		// check (de/en)codings of public key
 		pubKey := tc.privKey.PubKey()
 		var pub2, pub3, pub4 PubKey
-		checkWire(t, pubKey, &pub2, tc.keyType)
+		checkWire(t, pubKey, &pub2, tc.keyType, tc.pubSize)
 		assert.EqualValues(t, pubKey, pub2)
 		checkJSON(t, pubKey, &pub3, tc.keyName)
 		assert.EqualValues(t, pubKey, pub3)
@@ -125,4 +133,51 @@ func TestNilEncodings(t *testing.T) {
 	toFromJSON(t, e, &f)
 	assert.EqualValues(t, e, f)
 
+}
+
+type SigMessage struct {
+	Key PubKey
+	Sig Signature
+}
+
+func (s SigMessage) Bytes() []byte {
+	return wire.BinaryBytes(s)
+}
+
+func TestEmbededWireEncodings(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		privKey PrivKey
+		keyType byte
+		keyName string
+		size    int // pub + sig size
+	}{
+		{
+			privKey: GenPrivKeyEd25519().Wrap(),
+			keyType: TypeEd25519,
+			keyName: NameEd25519,
+			size:    2 + 32 + 64,
+		},
+		// {
+		// 	privKey: GenPrivKeySecp256k1().Wrap(),
+		// 	keyType: TypeSecp256k1,
+		// 	keyName: NameSecp256k1,
+		// 	size:    2 + 33 + 72, // ugh, either 72 or 73 depending....
+		// },
+	}
+
+	payload := randBytes(20)
+	for i, tc := range cases {
+		pubKey := tc.privKey.PubKey()
+		sig := tc.privKey.Sign(payload)
+		assert.True(pubKey.VerifyBytes(payload, sig), "%d", i)
+
+		msg := SigMessage{
+			Key: pubKey,
+			Sig: sig,
+		}
+		var msg2 SigMessage
+		checkWire(t, msg, &msg2, tc.keyType, tc.size)
+	}
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -82,25 +82,21 @@ func TestKeyEncodings(t *testing.T) {
 
 	for _, tc := range cases {
 		// check (de/en)codings of private key
-		priv2 := PrivKey{}
+		var priv2, priv3, priv4 PrivKey
 		checkWire(t, tc.privKey, &priv2, tc.keyType)
 		assert.EqualValues(t, tc.privKey, priv2)
-		priv3 := PrivKey{}
 		checkJSON(t, tc.privKey, &priv3, tc.keyName)
 		assert.EqualValues(t, tc.privKey, priv3)
-		priv4 := PrivKey{}
 		checkWireJSON(t, tc.privKey, &priv4, tc.keyType)
 		assert.EqualValues(t, tc.privKey, priv4)
 
 		// check (de/en)codings of public key
 		pubKey := tc.privKey.PubKey()
-		pub2 := PubKey{}
+		var pub2, pub3, pub4 PubKey
 		checkWire(t, pubKey, &pub2, tc.keyType)
 		assert.EqualValues(t, pubKey, pub2)
-		pub3 := PubKey{}
 		checkJSON(t, pubKey, &pub3, tc.keyName)
 		assert.EqualValues(t, pubKey, pub3)
-		pub4 := PubKey{}
 		checkWireJSON(t, pubKey, &pub4, tc.keyType)
 		assert.EqualValues(t, pubKey, pub4)
 	}
@@ -115,17 +111,17 @@ func toFromJSON(t *testing.T, in interface{}, recvr interface{}) {
 
 func TestNilEncodings(t *testing.T) {
 	// make sure sigs are okay with nil
-	a, b := Signature{}, Signature{}
+	var a, b Signature
 	toFromJSON(t, a, &b)
 	assert.EqualValues(t, a, b)
 
 	// make sure sigs are okay with nil
-	c, d := PubKey{}, PubKey{}
+	var c, d PubKey
 	toFromJSON(t, c, &d)
 	assert.EqualValues(t, c, d)
 
 	// make sure sigs are okay with nil
-	e, f := PrivKey{}, PrivKey{}
+	var e, f PrivKey
 	toFromJSON(t, e, &f)
 	assert.EqualValues(t, e, f)
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,12 +1,14 @@
 package crypto
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	data "github.com/tendermint/go-data"
+	wire "github.com/tendermint/go-wire"
 )
 
 type byter interface {
@@ -48,19 +50,31 @@ func checkJSON(t *testing.T, in interface{}, reader interface{}, typ string) {
 	assert.True(t, strings.Contains(string(js), parts[1]))
 }
 
+// make sure go-wire json can still figure this out...
+func checkWireJSON(t *testing.T, in interface{}, reader interface{}, typ byte) {
+	// test to and from binary
+	var err error
+	js := wire.JSONBytes(in)
+	btyp := fmt.Sprintf("[%d,", typ)
+	assert.True(t, strings.HasPrefix(string(js), btyp), string(js))
+
+	wire.ReadJSON(reader, js, &err)
+	require.Nil(t, err, "%+v", err)
+}
+
 func TestKeyEncodings(t *testing.T) {
 	cases := []struct {
-		privKey PrivKeyS
+		privKey PrivKey
 		keyType byte
 		keyName string
 	}{
 		{
-			privKey: PrivKeyS{GenPrivKeyEd25519()},
+			privKey: GenPrivKeyEd25519().Wrap(),
 			keyType: TypeEd25519,
 			keyName: NameEd25519,
 		},
 		{
-			privKey: PrivKeyS{GenPrivKeySecp256k1()},
+			privKey: GenPrivKeySecp256k1().Wrap(),
 			keyType: TypeSecp256k1,
 			keyName: NameSecp256k1,
 		},
@@ -68,21 +82,23 @@ func TestKeyEncodings(t *testing.T) {
 
 	for _, tc := range cases {
 		// check (de/en)codings of private key
-		priv2 := PrivKeyS{}
+		var priv2, priv3, priv4 PrivKey
 		checkWire(t, tc.privKey, &priv2, tc.keyType)
 		assert.EqualValues(t, tc.privKey, priv2)
-		priv3 := PrivKeyS{}
 		checkJSON(t, tc.privKey, &priv3, tc.keyName)
 		assert.EqualValues(t, tc.privKey, priv3)
+		checkWireJSON(t, tc.privKey, &priv4, tc.keyType)
+		assert.EqualValues(t, tc.privKey, priv4)
 
 		// check (de/en)codings of public key
-		pubKey := PubKeyS{tc.privKey.PubKey()}
-		pub2 := PubKeyS{}
+		pubKey := tc.privKey.PubKey()
+		var pub2, pub3, pub4 PubKey
 		checkWire(t, pubKey, &pub2, tc.keyType)
 		assert.EqualValues(t, pubKey, pub2)
-		pub3 := PubKeyS{}
 		checkJSON(t, pubKey, &pub3, tc.keyName)
 		assert.EqualValues(t, pubKey, pub3)
+		checkWireJSON(t, pubKey, &pub4, tc.keyType)
+		assert.EqualValues(t, pubKey, pub4)
 	}
 }
 
@@ -95,17 +111,17 @@ func toFromJSON(t *testing.T, in interface{}, recvr interface{}) {
 
 func TestNilEncodings(t *testing.T) {
 	// make sure sigs are okay with nil
-	a, b := SignatureS{}, SignatureS{}
+	var a, b Signature
 	toFromJSON(t, a, &b)
 	assert.EqualValues(t, a, b)
 
 	// make sure sigs are okay with nil
-	c, d := PubKeyS{}, PubKeyS{}
+	var c, d PubKey
 	toFromJSON(t, c, &d)
 	assert.EqualValues(t, c, d)
 
 	// make sure sigs are okay with nil
-	e, f := PrivKeyS{}, PrivKeyS{}
+	var e, f PrivKey
 	toFromJSON(t, e, &f)
 	assert.EqualValues(t, e, f)
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,31 @@
+package: github.com/tendermint/go-crypto
+import:
+- package: github.com/btcsuite/btcd
+  subpackages:
+  - btcec
+- package: github.com/btcsuite/btcutil
+  subpackages:
+  - base58
+- package: github.com/tendermint/ed25519
+  subpackages:
+  - extra25519
+- package: github.com/tendermint/go-common
+- package: github.com/tendermint/go-data
+  version: develop
+- package: github.com/tendermint/go-wire
+  version: develop
+- package: golang.org/x/crypto
+  subpackages:
+  - blowfish
+  - nacl/secretbox
+  - openpgp/armor
+  - ripemd160
+testImport:
+- package: github.com/mndrix/btcutil
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+  - require
+- package: github.com/tyler-smith/go-bip32
+- package: github.com/tyler-smith/go-bip39

--- a/hd/address.go
+++ b/hd/address.go
@@ -219,7 +219,7 @@ func I64(key []byte, data []byte) ([]byte, []byte) {
 
 // This returns a Bitcoin-like address.
 func AddrFromPubKeyBytes(pubKeyBytes []byte) string {
-	prefix := byte(0x80) // TODO Make const or configurable
+	prefix := byte(0x00) // TODO Make const or configurable
 	h160 := CalcHash160(pubKeyBytes)
 	h160 = append([]byte{prefix}, h160...)
 	checksum := CalcHash256(h160)
@@ -228,7 +228,7 @@ func AddrFromPubKeyBytes(pubKeyBytes []byte) string {
 }
 
 func AddrBytesFromPubKeyBytes(pubKeyBytes []byte) (addrBytes []byte, checksum []byte) {
-	prefix := byte(0x80) // TODO Make const or configurable
+	prefix := byte(0x00) // TODO Make const or configurable
 	h160 := CalcHash160(pubKeyBytes)
 	_h160 := append([]byte{prefix}, h160...)
 	checksum = CalcHash256(_h160)[:4]

--- a/hd/address.go
+++ b/hd/address.go
@@ -22,21 +22,13 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-const (
-	// BIP32 chainpath prefix
-	CHAINPATH_PREFIX_DEPOSIT   = 0
-	CHAINPATH_PREFIX_CHANGE    = 1
-	CHAINPATH_PREFIX_SWEEP     = 2
-	CHAINPATH_PREFIX_SWEEP_DRY = 102
-)
-
-func ComputeAddress(coin string, pubKeyHex string, chainHex string, path string, index int32) string {
+func ComputeAddress(pubKeyHex string, chainHex string, path string, index int32) string {
 	pubKeyBytes := DerivePublicKeyForPath(
 		HexDecode(pubKeyHex),
 		HexDecode(chainHex),
 		fmt.Sprintf("%v/%v", path, index),
 	)
-	return AddrFromPubKeyBytes(coin, pubKeyBytes)
+	return AddrFromPubKeyBytes(pubKeyBytes)
 }
 
 func ComputePrivateKey(mprivHex string, chainHex string, path string, index int32) string {
@@ -48,9 +40,9 @@ func ComputePrivateKey(mprivHex string, chainHex string, path string, index int3
 	return HexEncode(privKeyBytes)
 }
 
-func ComputeAddressForPrivKey(coin string, privKey string) string {
+func ComputeAddressForPrivKey(privKey string) string {
 	pubKeyBytes := PubKeyBytesFromPrivKeyBytes(HexDecode(privKey), true)
-	return AddrFromPubKeyBytes(coin, pubKeyBytes)
+	return AddrFromPubKeyBytes(pubKeyBytes)
 }
 
 func SignMessage(privKey string, message string, compress bool) string {
@@ -86,8 +78,8 @@ func ComputeMastersFromSeed(seed string) (string, string, string, string) {
 	return HexEncode(pubKeyBytes), HexEncode(secret), HexEncode(chain), HexEncode(secret)
 }
 
-func ComputeWIF(coin string, privKey string, compress bool) string {
-	return WIFFromPrivKeyBytes(coin, HexDecode(privKey), compress)
+func ComputeWIF(privKey string, compress bool) string {
+	return WIFFromPrivKeyBytes(HexDecode(privKey), compress)
 }
 
 func ComputeTxId(rawTxHex string) string {
@@ -100,7 +92,7 @@ func printKeyInfo(privKeyBytes []byte, pubKeyBytes []byte, chain []byte) {
 	if pubKeyBytes == nil {
 		pubKeyBytes = PubKeyBytesFromPrivKeyBytes(privKeyBytes, true)
 	}
-	addr := AddrFromPubKeyBytes("BTC", pubKeyBytes)
+	addr := AddrFromPubKeyBytes(pubKeyBytes)
 	log.Println("\nprikey:\t%v\npubKeyBytes:\t%v\naddr:\t%v\nchain:\t%v",
 		HexEncode(privKeyBytes),
 		HexEncode(pubKeyBytes),
@@ -225,8 +217,9 @@ func I64(key []byte, data []byte) ([]byte, []byte) {
 	return I[:32], I[32:]
 }
 
-func AddrFromPubKeyBytes(coin string, pubKeyBytes []byte) string {
-	prefix := byte(0x00) // TODO Make const or configurable
+// This returns a Bitcoin-like address.
+func AddrFromPubKeyBytes(pubKeyBytes []byte) string {
+	prefix := byte(0x80) // TODO Make const or configurable
 	h160 := CalcHash160(pubKeyBytes)
 	h160 = append([]byte{prefix}, h160...)
 	checksum := CalcHash256(h160)
@@ -234,7 +227,15 @@ func AddrFromPubKeyBytes(coin string, pubKeyBytes []byte) string {
 	return base58.Encode(b)
 }
 
-func WIFFromPrivKeyBytes(coin string, privKeyBytes []byte, compress bool) string {
+func AddrBytesFromPubKeyBytes(pubKeyBytes []byte) (addrBytes []byte, checksum []byte) {
+	prefix := byte(0x80) // TODO Make const or configurable
+	h160 := CalcHash160(pubKeyBytes)
+	_h160 := append([]byte{prefix}, h160...)
+	checksum = CalcHash256(_h160)[:4]
+	return h160, checksum
+}
+
+func WIFFromPrivKeyBytes(privKeyBytes []byte, compress bool) string {
 	prefix := byte(0x80) // TODO Make const or configurable
 	bytes := append([]byte{prefix}, privKeyBytes...)
 	if compress {

--- a/priv_key.go
+++ b/priv_key.go
@@ -64,6 +64,8 @@ var privKeyMapper = data.NewMapper(PrivKey{}).
 
 //-------------------------------------
 
+var _ PrivKeyInner = PrivKeyEd25519{}
+
 // Implements PrivKey
 type PrivKeyEd25519 [64]byte
 
@@ -148,6 +150,8 @@ func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519 {
 }
 
 //-------------------------------------
+
+var _ PrivKeyInner = PrivKeySecp256k1{}
 
 // Implements PrivKey
 type PrivKeySecp256k1 [32]byte

--- a/priv_key.go
+++ b/priv_key.go
@@ -32,8 +32,8 @@ var privKeyMapper data.Mapper
 // register both private key types with go-data (and thus go-wire)
 func init() {
 	privKeyMapper = data.NewMapper(PrivKeyS{}).
-		RegisterInterface(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
-		RegisterInterface(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
+		RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
+		RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
 // PrivKeyS add json serialization to PrivKey

--- a/priv_key.go
+++ b/priv_key.go
@@ -11,7 +11,14 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-// PrivKeyInner is now the interface itself, use PrivKey in all code
+/*
+DO NOT USE this interface.
+
+It is public by necessity but should never be used directly
+outside of this package.
+
+Only use the PrivKey, never the PrivKeyInner
+*/
 type PrivKeyInner interface {
 	Bytes() []byte
 	Sign(msg []byte) Signature
@@ -36,11 +43,13 @@ func init() {
 		RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
-// PrivKey handles all encoding and exposes methods
+// PrivKey should be used instead of an interface in all external packages
+// unless you demand a concrete implementation, then use that directly.
 type PrivKey struct {
 	PrivKeyInner `json:"unwrap"`
 }
 
+// WrapPrivKey goes from concrete implementation to "interface" struct
 func WrapPrivKey(pk PrivKeyInner) PrivKey {
 	if wrap, ok := pk.(PrivKey); ok {
 		pk = wrap.Unwrap()
@@ -48,6 +57,7 @@ func WrapPrivKey(pk PrivKeyInner) PrivKey {
 	return PrivKey{pk}
 }
 
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
 func (p PrivKey) Unwrap() PrivKeyInner {
 	pk := p.PrivKeyInner
 	for wrap, ok := pk.(PrivKey); ok; wrap, ok = pk.(PrivKey) {

--- a/priv_key.go
+++ b/priv_key.go
@@ -41,6 +41,13 @@ type PrivKeyS struct {
 	PrivKey
 }
 
+func WrapPrivKey(pk PrivKey) PrivKeyS {
+	for ppk, ok := pk.(PrivKeyS); ok; ppk, ok = pk.(PrivKeyS) {
+		pk = ppk.PrivKey
+	}
+	return PrivKeyS{pk}
+}
+
 func (p PrivKeyS) MarshalJSON() ([]byte, error) {
 	return privKeyMapper.ToJSON(p.PrivKey)
 }

--- a/priv_key.go
+++ b/priv_key.go
@@ -38,7 +38,7 @@ func init() {
 
 // PrivKey handles all encoding and exposes methods
 type PrivKey struct {
-	PrivKeyInner
+	PrivKeyInner `json:"unwrap"`
 }
 
 func WrapPrivKey(pk PrivKeyInner) PrivKey {

--- a/priv_key.go
+++ b/priv_key.go
@@ -11,59 +11,26 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-/*
-DO NOT USE this interface.
-
-It is public by necessity but should never be used directly
-outside of this package.
-
-Only use the PrivKey, never the PrivKeyInner
-*/
-type PrivKeyInner interface {
-	Bytes() []byte
-	Sign(msg []byte) Signature
-	PubKey() PubKey
-	Equals(PrivKey) bool
+func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
+	err = wire.ReadBinaryBytes(privKeyBytes, &privKey)
+	return
 }
 
-// Types of implementations
-const (
-	TypeEd25519   = byte(0x01)
-	TypeSecp256k1 = byte(0x02)
-	NameEd25519   = "ed25519"
-	NameSecp256k1 = "secp256k1"
-)
+//----------------------------------------
 
-var privKeyMapper data.Mapper
-
-// register both private key types with go-data (and thus go-wire)
-func init() {
-	privKeyMapper = data.NewMapper(PrivKey{}).
-		RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
-		RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
-}
-
-// PrivKey should be used instead of an interface in all external packages
-// unless you demand a concrete implementation, then use that directly.
 type PrivKey struct {
 	PrivKeyInner `json:"unwrap"`
 }
 
-// WrapPrivKey goes from concrete implementation to "interface" struct
-func WrapPrivKey(pk PrivKeyInner) PrivKey {
-	if wrap, ok := pk.(PrivKey); ok {
-		pk = wrap.Unwrap()
-	}
-	return PrivKey{pk}
-}
-
-// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
-func (p PrivKey) Unwrap() PrivKeyInner {
-	pk := p.PrivKeyInner
-	for wrap, ok := pk.(PrivKey); ok; wrap, ok = pk.(PrivKey) {
-		pk = wrap.PrivKeyInner
-	}
-	return pk
+// DO NOT USE THIS INTERFACE.
+// You probably want to use PubKey
+type PrivKeyInner interface {
+	AssertIsPrivKeyInner()
+	Bytes() []byte
+	Sign(msg []byte) Signature
+	PubKey() PubKey
+	Equals(PrivKey) bool
+	Wrap() PrivKey
 }
 
 func (p PrivKey) MarshalJSON() ([]byte, error) {
@@ -78,19 +45,29 @@ func (p *PrivKey) UnmarshalJSON(data []byte) (err error) {
 	return
 }
 
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+func (p PrivKey) Unwrap() PrivKeyInner {
+	pk := p.PrivKeyInner
+	for wrap, ok := pk.(PrivKey); ok; wrap, ok = pk.(PrivKey) {
+		pk = wrap.PrivKeyInner
+	}
+	return pk
+}
+
 func (p PrivKey) Empty() bool {
 	return p.PrivKeyInner == nil
 }
 
-func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
-	err = wire.ReadBinaryBytes(privKeyBytes, &privKey)
-	return
-}
+var privKeyMapper = data.NewMapper(PrivKey{}).
+	RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
+	RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 
 //-------------------------------------
 
 // Implements PrivKey
 type PrivKeyEd25519 [64]byte
+
+func (privKey PrivKeyEd25519) AssertIsPrivKeyInner() {}
 
 func (privKey PrivKeyEd25519) Bytes() []byte {
 	return wire.BinaryBytes(PrivKey{privKey})
@@ -99,13 +76,13 @@ func (privKey PrivKeyEd25519) Bytes() []byte {
 func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
 	privKeyBytes := [64]byte(privKey)
 	signatureBytes := ed25519.Sign(&privKeyBytes, msg)
-	return WrapSignature(SignatureEd25519(*signatureBytes))
+	return SignatureEd25519(*signatureBytes).Wrap()
 }
 
 func (privKey PrivKeyEd25519) PubKey() PubKey {
 	privKeyBytes := [64]byte(privKey)
 	pubBytes := *ed25519.MakePublicKey(&privKeyBytes)
-	return WrapPubKey(PubKeyEd25519(pubBytes))
+	return PubKeyEd25519(pubBytes).Wrap()
 }
 
 func (privKey PrivKeyEd25519) Equals(other PrivKey) bool {
@@ -149,6 +126,10 @@ func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519 {
 	return PrivKeyEd25519(newKey)
 }
 
+func (privKey PrivKeyEd25519) Wrap() PrivKey {
+	return PrivKey{privKey}
+}
+
 func GenPrivKeyEd25519() PrivKeyEd25519 {
 	privKeyBytes := new([64]byte)
 	copy(privKeyBytes[:32], CRandBytes(32))
@@ -171,6 +152,8 @@ func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519 {
 // Implements PrivKey
 type PrivKeySecp256k1 [32]byte
 
+func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner() {}
+
 func (privKey PrivKeySecp256k1) Bytes() []byte {
 	return wire.BinaryBytes(PrivKey{privKey})
 }
@@ -181,14 +164,14 @@ func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
 	if err != nil {
 		PanicSanity(err)
 	}
-	return WrapSignature(SignatureSecp256k1(sig__.Serialize()))
+	return SignatureSecp256k1(sig__.Serialize()).Wrap()
 }
 
 func (privKey PrivKeySecp256k1) PubKey() PubKey {
 	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
 	pub := [64]byte{}
 	copy(pub[:], pub__.SerializeUncompressed()[1:])
-	return WrapPubKey(PubKeySecp256k1(pub))
+	return PubKeySecp256k1(pub).Wrap()
 }
 
 func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool {
@@ -212,6 +195,10 @@ func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error {
 
 func (privKey PrivKeySecp256k1) String() string {
 	return Fmt("PrivKeySecp256k1{*****}")
+}
+
+func (privKey PrivKeySecp256k1) Wrap() PrivKey {
+	return PrivKey{privKey}
 }
 
 /*

--- a/priv_key.go
+++ b/priv_key.go
@@ -1,12 +1,6 @@
 package crypto
 
 import (
-	"bytes"
-
-	secp256k1 "github.com/btcsuite/btcd/btcec"
-	"github.com/tendermint/ed25519"
-	"github.com/tendermint/ed25519/extra25519"
-	. "github.com/tendermint/go-common"
 	data "github.com/tendermint/go-data"
 	"github.com/tendermint/go-wire"
 )
@@ -21,6 +15,8 @@ func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
 type PrivKey struct {
 	PrivKeyInner `json:"unwrap"`
 }
+
+var privKeyMapper = data.NewMapper(PrivKey{})
 
 // DO NOT USE THIS INTERFACE.
 // You probably want to use PubKey
@@ -56,182 +52,4 @@ func (p PrivKey) Unwrap() PrivKeyInner {
 
 func (p PrivKey) Empty() bool {
 	return p.PrivKeyInner == nil
-}
-
-var privKeyMapper = data.NewMapper(PrivKey{}).
-	RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
-	RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
-
-//-------------------------------------
-
-var _ PrivKeyInner = PrivKeyEd25519{}
-
-// Implements PrivKey
-type PrivKeyEd25519 [64]byte
-
-func (privKey PrivKeyEd25519) AssertIsPrivKeyInner() {}
-
-func (privKey PrivKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(PrivKey{privKey})
-}
-
-func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
-	privKeyBytes := [64]byte(privKey)
-	signatureBytes := ed25519.Sign(&privKeyBytes, msg)
-	return SignatureEd25519(*signatureBytes).Wrap()
-}
-
-func (privKey PrivKeyEd25519) PubKey() PubKey {
-	privKeyBytes := [64]byte(privKey)
-	pubBytes := *ed25519.MakePublicKey(&privKeyBytes)
-	return PubKeyEd25519(pubBytes).Wrap()
-}
-
-func (privKey PrivKeyEd25519) Equals(other PrivKey) bool {
-	if otherEd, ok := other.Unwrap().(PrivKeyEd25519); ok {
-		return bytes.Equal(privKey[:], otherEd[:])
-	} else {
-		return false
-	}
-}
-
-func (p PrivKeyEd25519) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p[:])
-}
-
-func (p *PrivKeyEd25519) UnmarshalJSON(enc []byte) error {
-	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(p[:], ref)
-	return err
-}
-
-func (privKey PrivKeyEd25519) ToCurve25519() *[32]byte {
-	keyCurve25519 := new([32]byte)
-	privKeyBytes := [64]byte(privKey)
-	extra25519.PrivateKeyToCurve25519(keyCurve25519, &privKeyBytes)
-	return keyCurve25519
-}
-
-func (privKey PrivKeyEd25519) String() string {
-	return Fmt("PrivKeyEd25519{*****}")
-}
-
-// Deterministically generates new priv-key bytes from key.
-func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519 {
-	newBytes := wire.BinarySha256(struct {
-		PrivKey [64]byte
-		Index   int
-	}{privKey, index})
-	var newKey [64]byte
-	copy(newKey[:], newBytes)
-	return PrivKeyEd25519(newKey)
-}
-
-func (privKey PrivKeyEd25519) Wrap() PrivKey {
-	return PrivKey{privKey}
-}
-
-func GenPrivKeyEd25519() PrivKeyEd25519 {
-	privKeyBytes := new([64]byte)
-	copy(privKeyBytes[:32], CRandBytes(32))
-	ed25519.MakePublicKey(privKeyBytes)
-	return PrivKeyEd25519(*privKeyBytes)
-}
-
-// NOTE: secret should be the output of a KDF like bcrypt,
-// if it's derived from user input.
-func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519 {
-	privKey32 := Sha256(secret) // Not Ripemd160 because we want 32 bytes.
-	privKeyBytes := new([64]byte)
-	copy(privKeyBytes[:32], privKey32)
-	ed25519.MakePublicKey(privKeyBytes)
-	return PrivKeyEd25519(*privKeyBytes)
-}
-
-//-------------------------------------
-
-var _ PrivKeyInner = PrivKeySecp256k1{}
-
-// Implements PrivKey
-type PrivKeySecp256k1 [32]byte
-
-func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner() {}
-
-func (privKey PrivKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(PrivKey{privKey})
-}
-
-func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
-	priv__, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
-	sig__, err := priv__.Sign(Sha256(msg))
-	if err != nil {
-		PanicSanity(err)
-	}
-	return SignatureSecp256k1(sig__.Serialize()).Wrap()
-}
-
-func (privKey PrivKeySecp256k1) PubKey() PubKey {
-	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
-	var pub PubKeySecp256k1
-	copy(pub[:], pub__.SerializeCompressed())
-	return pub.Wrap()
-}
-
-func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool {
-	if otherSecp, ok := other.Unwrap().(PrivKeySecp256k1); ok {
-		return bytes.Equal(privKey[:], otherSecp[:])
-	} else {
-		return false
-	}
-}
-
-func (p PrivKeySecp256k1) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p[:])
-}
-
-func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error {
-	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(p[:], ref)
-	return err
-}
-
-func (privKey PrivKeySecp256k1) String() string {
-	return Fmt("PrivKeySecp256k1{*****}")
-}
-
-func (privKey PrivKeySecp256k1) Wrap() PrivKey {
-	return PrivKey{privKey}
-}
-
-/*
-// Deterministically generates new priv-key bytes from key.
-func (key PrivKeySecp256k1) Generate(index int) PrivKeySecp256k1 {
-	newBytes := wire.BinarySha256(struct {
-		PrivKey [64]byte
-		Index   int
-	}{key, index})
-	var newKey [64]byte
-	copy(newKey[:], newBytes)
-	return PrivKeySecp256k1(newKey)
-}
-*/
-
-func GenPrivKeySecp256k1() PrivKeySecp256k1 {
-	privKeyBytes := [32]byte{}
-	copy(privKeyBytes[:], CRandBytes(32))
-	priv, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKeyBytes[:])
-	copy(privKeyBytes[:], priv.Serialize())
-	return PrivKeySecp256k1(privKeyBytes)
-}
-
-// NOTE: secret should be the output of a KDF like bcrypt,
-// if it's derived from user input.
-func GenPrivKeySecp256k1FromSecret(secret []byte) PrivKeySecp256k1 {
-	privKey32 := Sha256(secret) // Not Ripemd160 because we want 32 bytes.
-	priv, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey32)
-	privKeyBytes := [32]byte{}
-	copy(privKeyBytes[:], priv.Serialize())
-	return PrivKeySecp256k1(privKeyBytes)
 }

--- a/priv_key.go
+++ b/priv_key.go
@@ -11,8 +11,8 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-// PrivKey is part of PrivAccount and state.PrivValidator.
-type PrivKey interface {
+// PrivKeyInner is now the interface itself, use PrivKey in all code
+type PrivKeyInner interface {
 	Bytes() []byte
 	Sign(msg []byte) Signature
 	PubKey() PubKey
@@ -31,37 +31,45 @@ var privKeyMapper data.Mapper
 
 // register both private key types with go-data (and thus go-wire)
 func init() {
-	privKeyMapper = data.NewMapper(PrivKeyS{}).
+	privKeyMapper = data.NewMapper(PrivKey{}).
 		RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
 		RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
-// PrivKeyS add json serialization to PrivKey
-type PrivKeyS struct {
-	PrivKey
+// PrivKey handles all encoding and exposes methods
+type PrivKey struct {
+	PrivKeyInner
 }
 
-func WrapPrivKey(pk PrivKey) PrivKeyS {
-	for ppk, ok := pk.(PrivKeyS); ok; ppk, ok = pk.(PrivKeyS) {
-		pk = ppk.PrivKey
+func WrapPrivKey(pk PrivKeyInner) PrivKey {
+	if wrap, ok := pk.(PrivKey); ok {
+		pk = wrap.Unwrap()
 	}
-	return PrivKeyS{pk}
+	return PrivKey{pk}
 }
 
-func (p PrivKeyS) MarshalJSON() ([]byte, error) {
-	return privKeyMapper.ToJSON(p.PrivKey)
+func (p PrivKey) Unwrap() PrivKeyInner {
+	pk := p.PrivKeyInner
+	for wrap, ok := pk.(PrivKey); ok; wrap, ok = pk.(PrivKey) {
+		pk = wrap.PrivKeyInner
+	}
+	return pk
 }
 
-func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error) {
+func (p PrivKey) MarshalJSON() ([]byte, error) {
+	return privKeyMapper.ToJSON(p.PrivKeyInner)
+}
+
+func (p *PrivKey) UnmarshalJSON(data []byte) (err error) {
 	parsed, err := privKeyMapper.FromJSON(data)
 	if err == nil && parsed != nil {
-		p.PrivKey = parsed.(PrivKey)
+		p.PrivKeyInner = parsed.(PrivKeyInner)
 	}
 	return
 }
 
-func (p PrivKeyS) Empty() bool {
-	return p.PrivKey == nil
+func (p PrivKey) Empty() bool {
+	return p.PrivKeyInner == nil
 }
 
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
@@ -75,22 +83,23 @@ func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
 type PrivKeyEd25519 [64]byte
 
 func (privKey PrivKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PrivKey }{privKey})
+	return wire.BinaryBytes(PrivKey{privKey})
 }
 
 func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
 	privKeyBytes := [64]byte(privKey)
 	signatureBytes := ed25519.Sign(&privKeyBytes, msg)
-	return SignatureEd25519(*signatureBytes)
+	return WrapSignature(SignatureEd25519(*signatureBytes))
 }
 
 func (privKey PrivKeyEd25519) PubKey() PubKey {
 	privKeyBytes := [64]byte(privKey)
-	return PubKeyEd25519(*ed25519.MakePublicKey(&privKeyBytes))
+	pubBytes := *ed25519.MakePublicKey(&privKeyBytes)
+	return WrapPubKey(PubKeyEd25519(pubBytes))
 }
 
 func (privKey PrivKeyEd25519) Equals(other PrivKey) bool {
-	if otherEd, ok := other.(PrivKeyEd25519); ok {
+	if otherEd, ok := other.Unwrap().(PrivKeyEd25519); ok {
 		return bytes.Equal(privKey[:], otherEd[:])
 	} else {
 		return false
@@ -153,7 +162,7 @@ func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519 {
 type PrivKeySecp256k1 [32]byte
 
 func (privKey PrivKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PrivKey }{privKey})
+	return wire.BinaryBytes(PrivKey{privKey})
 }
 
 func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
@@ -162,18 +171,18 @@ func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
 	if err != nil {
 		PanicSanity(err)
 	}
-	return SignatureSecp256k1(sig__.Serialize())
+	return WrapSignature(SignatureSecp256k1(sig__.Serialize()))
 }
 
 func (privKey PrivKeySecp256k1) PubKey() PubKey {
 	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
 	pub := [64]byte{}
 	copy(pub[:], pub__.SerializeUncompressed()[1:])
-	return PubKeySecp256k1(pub)
+	return WrapPubKey(PubKeySecp256k1(pub))
 }
 
 func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool {
-	if otherSecp, ok := other.(PrivKeySecp256k1); ok {
+	if otherSecp, ok := other.Unwrap().(PrivKeySecp256k1); ok {
 		return bytes.Equal(privKey[:], otherSecp[:])
 	} else {
 		return false

--- a/priv_key.go
+++ b/priv_key.go
@@ -11,79 +11,82 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-// PrivKey is part of PrivAccount and state.PrivValidator.
-type PrivKey interface {
-	Bytes() []byte
-	Sign(msg []byte) Signature
-	PubKey() PubKey
-	Equals(PrivKey) bool
-}
-
-// Types of implementations
-const (
-	TypeEd25519   = byte(0x01)
-	TypeSecp256k1 = byte(0x02)
-	NameEd25519   = "ed25519"
-	NameSecp256k1 = "secp256k1"
-)
-
-var privKeyMapper data.Mapper
-
-// register both private key types with go-data (and thus go-wire)
-func init() {
-	privKeyMapper = data.NewMapper(PrivKeyS{}).
-		RegisterInterface(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
-		RegisterInterface(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
-}
-
-// PrivKeyS add json serialization to PrivKey
-type PrivKeyS struct {
-	PrivKey
-}
-
-func (p PrivKeyS) MarshalJSON() ([]byte, error) {
-	return privKeyMapper.ToJSON(p.PrivKey)
-}
-
-func (p *PrivKeyS) UnmarshalJSON(data []byte) (err error) {
-	parsed, err := privKeyMapper.FromJSON(data)
-	if err == nil && parsed != nil {
-		p.PrivKey = parsed.(PrivKey)
-	}
-	return
-}
-
-func (p PrivKeyS) Empty() bool {
-	return p.PrivKey == nil
-}
-
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey PrivKey, err error) {
 	err = wire.ReadBinaryBytes(privKeyBytes, &privKey)
 	return
 }
+
+//----------------------------------------
+
+type PrivKey struct {
+	PrivKeyInner `json:"unwrap"`
+}
+
+// DO NOT USE THIS INTERFACE.
+// You probably want to use PubKey
+type PrivKeyInner interface {
+	AssertIsPrivKeyInner()
+	Bytes() []byte
+	Sign(msg []byte) Signature
+	PubKey() PubKey
+	Equals(PrivKey) bool
+	Wrap() PrivKey
+}
+
+func (p PrivKey) MarshalJSON() ([]byte, error) {
+	return privKeyMapper.ToJSON(p.PrivKeyInner)
+}
+
+func (p *PrivKey) UnmarshalJSON(data []byte) (err error) {
+	parsed, err := privKeyMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		p.PrivKeyInner = parsed.(PrivKeyInner)
+	}
+	return
+}
+
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+func (p PrivKey) Unwrap() PrivKeyInner {
+	pk := p.PrivKeyInner
+	for wrap, ok := pk.(PrivKey); ok; wrap, ok = pk.(PrivKey) {
+		pk = wrap.PrivKeyInner
+	}
+	return pk
+}
+
+func (p PrivKey) Empty() bool {
+	return p.PrivKeyInner == nil
+}
+
+var privKeyMapper = data.NewMapper(PrivKey{}).
+	RegisterImplementation(PrivKeyEd25519{}, NameEd25519, TypeEd25519).
+	RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 
 //-------------------------------------
 
 // Implements PrivKey
 type PrivKeyEd25519 [64]byte
 
+func (privKey PrivKeyEd25519) AssertIsPrivKeyInner() {}
+
 func (privKey PrivKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PrivKey }{privKey})
+	return wire.BinaryBytes(PrivKey{privKey})
 }
 
 func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
 	privKeyBytes := [64]byte(privKey)
 	signatureBytes := ed25519.Sign(&privKeyBytes, msg)
-	return SignatureEd25519(*signatureBytes)
+	return SignatureEd25519(*signatureBytes).Wrap()
 }
 
 func (privKey PrivKeyEd25519) PubKey() PubKey {
 	privKeyBytes := [64]byte(privKey)
-	return PubKeyEd25519(*ed25519.MakePublicKey(&privKeyBytes))
+	pubBytes := *ed25519.MakePublicKey(&privKeyBytes)
+	return PubKeyEd25519(pubBytes).Wrap()
 }
 
 func (privKey PrivKeyEd25519) Equals(other PrivKey) bool {
-	if otherEd, ok := other.(PrivKeyEd25519); ok {
+	if otherEd, ok := other.Unwrap().(PrivKeyEd25519); ok {
 		return bytes.Equal(privKey[:], otherEd[:])
 	} else {
 		return false
@@ -123,6 +126,10 @@ func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519 {
 	return PrivKeyEd25519(newKey)
 }
 
+func (privKey PrivKeyEd25519) Wrap() PrivKey {
+	return PrivKey{privKey}
+}
+
 func GenPrivKeyEd25519() PrivKeyEd25519 {
 	privKeyBytes := new([64]byte)
 	copy(privKeyBytes[:32], CRandBytes(32))
@@ -145,8 +152,10 @@ func GenPrivKeyEd25519FromSecret(secret []byte) PrivKeyEd25519 {
 // Implements PrivKey
 type PrivKeySecp256k1 [32]byte
 
+func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner() {}
+
 func (privKey PrivKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PrivKey }{privKey})
+	return wire.BinaryBytes(PrivKey{privKey})
 }
 
 func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
@@ -155,18 +164,18 @@ func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
 	if err != nil {
 		PanicSanity(err)
 	}
-	return SignatureSecp256k1(sig__.Serialize())
+	return SignatureSecp256k1(sig__.Serialize()).Wrap()
 }
 
 func (privKey PrivKeySecp256k1) PubKey() PubKey {
 	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
 	var pub PubKeySecp256k1
 	copy(pub[:], pub__.SerializeCompressed())
-	return pub
+	return pub.Wrap()
 }
 
 func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool {
-	if otherSecp, ok := other.(PrivKeySecp256k1); ok {
+	if otherSecp, ok := other.Unwrap().(PrivKeySecp256k1); ok {
 		return bytes.Equal(privKey[:], otherSecp[:])
 	} else {
 		return false
@@ -186,6 +195,10 @@ func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error {
 
 func (privKey PrivKeySecp256k1) String() string {
 	return Fmt("PrivKeySecp256k1{*****}")
+}
+
+func (privKey PrivKeySecp256k1) Wrap() PrivKey {
+	return PrivKey{privKey}
 }
 
 /*

--- a/priv_key.go
+++ b/priv_key.go
@@ -22,11 +22,14 @@ var privKeyMapper = data.NewMapper(PrivKey{})
 // You probably want to use PubKey
 type PrivKeyInner interface {
 	AssertIsPrivKeyInner()
-	Bytes() []byte
 	Sign(msg []byte) Signature
 	PubKey() PubKey
 	Equals(PrivKey) bool
 	Wrap() PrivKey
+}
+
+func (p PrivKey) Bytes() []byte {
+	return wire.BinaryBytes(p)
 }
 
 func (p PrivKey) MarshalJSON() ([]byte, error) {

--- a/pub_key.go
+++ b/pub_key.go
@@ -67,6 +67,8 @@ var pubKeyMapper = data.NewMapper(PubKey{}).
 
 //-------------------------------------
 
+var _ PubKeyInner = PubKeyEd25519{}
+
 // Implements PubKeyInner
 type PubKeyEd25519 [32]byte
 
@@ -145,6 +147,8 @@ func (pubKey PubKeyEd25519) Wrap() PubKey {
 }
 
 //-------------------------------------
+
+var _ PubKeyInner = PubKeySecp256k1{}
 
 // Implements PubKey.
 // Compressed pubkey (just the x-cord),

--- a/pub_key.go
+++ b/pub_key.go
@@ -35,6 +35,13 @@ type PubKeyS struct {
 	PubKey
 }
 
+func WrapPubKey(pk PubKey) PubKeyS {
+	for ppk, ok := pk.(PubKeyS); ok; ppk, ok = pk.(PubKeyS) {
+		pk = ppk.PubKey
+	}
+	return PubKeyS{pk}
+}
+
 func (p PubKeyS) MarshalJSON() ([]byte, error) {
 	return pubKeyMapper.ToJSON(p.PubKey)
 }

--- a/pub_key.go
+++ b/pub_key.go
@@ -13,54 +13,64 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-// PubKey is part of Account and Validator.
-type PubKey interface {
-	Address() []byte
-	Bytes() []byte
-	KeyString() string
-	VerifyBytes(msg []byte, sig Signature) bool
-	Equals(PubKey) bool
-}
-
-var pubKeyMapper data.Mapper
-
-// register both public key types with go-data (and thus go-wire)
-func init() {
-	pubKeyMapper = data.NewMapper(PubKeyS{}).
-		RegisterInterface(PubKeyEd25519{}, NameEd25519, TypeEd25519).
-		RegisterInterface(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
-}
-
-// PubKeyS add json serialization to PubKey
-type PubKeyS struct {
-	PubKey
-}
-
-func (p PubKeyS) MarshalJSON() ([]byte, error) {
-	return pubKeyMapper.ToJSON(p.PubKey)
-}
-
-func (p *PubKeyS) UnmarshalJSON(data []byte) (err error) {
-	parsed, err := pubKeyMapper.FromJSON(data)
-	if err == nil && parsed != nil {
-		p.PubKey = parsed.(PubKey)
-	}
-	return
-}
-
-func (p PubKeyS) Empty() bool {
-	return p.PubKey == nil
-}
-
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
 	err = wire.ReadBinaryBytes(pubKeyBytes, &pubKey)
 	return
 }
 
+//----------------------------------------
+
+type PubKey struct {
+	PubKeyInner `json:"unwrap"`
+}
+
+// DO NOT USE THIS INTERFACE.
+// You probably want to use PubKey
+type PubKeyInner interface {
+	AssertIsPubKeyInner()
+	Address() []byte
+	Bytes() []byte
+	KeyString() string
+	VerifyBytes(msg []byte, sig Signature) bool
+	Equals(PubKey) bool
+	Wrap() PubKey
+}
+
+func (pk PubKey) MarshalJSON() ([]byte, error) {
+	return pubKeyMapper.ToJSON(pk.PubKeyInner)
+}
+
+func (pk *PubKey) UnmarshalJSON(data []byte) (err error) {
+	parsed, err := pubKeyMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		pk.PubKeyInner = parsed.(PubKeyInner)
+	}
+	return
+}
+
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+func (pk PubKey) Unwrap() PubKeyInner {
+	pkI := pk.PubKeyInner
+	for wrap, ok := pkI.(PubKey); ok; wrap, ok = pkI.(PubKey) {
+		pkI = wrap.PubKeyInner
+	}
+	return pkI
+}
+
+func (p PubKey) Empty() bool {
+	return p.PubKeyInner == nil
+}
+
+var pubKeyMapper = data.NewMapper(PubKey{}).
+	RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519).
+	RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
+
 //-------------------------------------
 
-// Implements PubKey
+// Implements PubKeyInner
 type PubKeyEd25519 [32]byte
+
+func (pubKey PubKeyEd25519) AssertIsPubKeyInner() {}
 
 func (pubKey PubKeyEd25519) Address() []byte {
 	w, n, err := new(bytes.Buffer), new(int), new(error)
@@ -76,16 +86,12 @@ func (pubKey PubKeyEd25519) Address() []byte {
 }
 
 func (pubKey PubKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PubKey }{pubKey})
+	return wire.BinaryBytes(PubKey{pubKey})
 }
 
 func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
-	// unwrap if needed
-	if wrap, ok := sig_.(SignatureS); ok {
-		sig_ = wrap.Signature
-	}
 	// make sure we use the same algorithm to sign
-	sig, ok := sig_.(SignatureEd25519)
+	sig, ok := sig_.Unwrap().(SignatureEd25519)
 	if !ok {
 		return false
 	}
@@ -127,11 +133,15 @@ func (pubKey PubKeyEd25519) KeyString() string {
 }
 
 func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
-	if otherEd, ok := other.(PubKeyEd25519); ok {
+	if otherEd, ok := other.Unwrap().(PubKeyEd25519); ok {
 		return bytes.Equal(pubKey[:], otherEd[:])
 	} else {
 		return false
 	}
+}
+
+func (pubKey PubKeyEd25519) Wrap() PubKey {
+	return PubKey{pubKey}
 }
 
 //-------------------------------------
@@ -140,6 +150,8 @@ func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
 // Compressed pubkey (just the x-cord),
 // prefixed with 0x02 or 0x03, depending on the y-cord.
 type PubKeySecp256k1 [33]byte
+
+func (pubKey PubKeySecp256k1) AssertIsPubKeyInner() {}
 
 // Implements Bitcoin style addresses: RIPEMD160(SHA256(pubkey))
 func (pubKey PubKeySecp256k1) Address() []byte {
@@ -153,16 +165,12 @@ func (pubKey PubKeySecp256k1) Address() []byte {
 }
 
 func (pubKey PubKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PubKey }{pubKey})
+	return wire.BinaryBytes(PubKey{pubKey})
 }
 
 func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
-	// unwrap if needed
-	if wrap, ok := sig_.(SignatureS); ok {
-		sig_ = wrap.Signature
-	}
 	// and assert same algorithm to sign and verify
-	sig, ok := sig_.(SignatureSecp256k1)
+	sig, ok := sig_.Unwrap().(SignatureSecp256k1)
 	if !ok {
 		return false
 	}
@@ -200,9 +208,13 @@ func (pubKey PubKeySecp256k1) KeyString() string {
 }
 
 func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
-	if otherSecp, ok := other.(PubKeySecp256k1); ok {
+	if otherSecp, ok := other.Unwrap().(PubKeySecp256k1); ok {
 		return bytes.Equal(pubKey[:], otherSecp[:])
 	} else {
 		return false
 	}
+}
+
+func (pubKey PubKeySecp256k1) Wrap() PubKey {
+	return PubKey{pubKey}
 }

--- a/pub_key.go
+++ b/pub_key.go
@@ -23,11 +23,14 @@ var pubKeyMapper = data.NewMapper(PubKey{})
 type PubKeyInner interface {
 	AssertIsPubKeyInner()
 	Address() []byte
-	Bytes() []byte
 	KeyString() string
 	VerifyBytes(msg []byte, sig Signature) bool
 	Equals(PubKey) bool
 	Wrap() PubKey
+}
+
+func (p PubKey) Bytes() []byte {
+	return wire.BinaryBytes(p)
 }
 
 func (pk PubKey) MarshalJSON() ([]byte, error) {

--- a/pub_key.go
+++ b/pub_key.go
@@ -1,16 +1,8 @@
 package crypto
 
 import (
-	"bytes"
-	"crypto/sha256"
-
-	secp256k1 "github.com/btcsuite/btcd/btcec"
-	"github.com/tendermint/ed25519"
-	"github.com/tendermint/ed25519/extra25519"
-	. "github.com/tendermint/go-common"
 	data "github.com/tendermint/go-data"
 	"github.com/tendermint/go-wire"
-	"golang.org/x/crypto/ripemd160"
 )
 
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
@@ -23,6 +15,8 @@ func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
 type PubKey struct {
 	PubKeyInner `json:"unwrap"`
 }
+
+var pubKeyMapper = data.NewMapper(PubKey{})
 
 // DO NOT USE THIS INTERFACE.
 // You probably want to use PubKey
@@ -59,166 +53,4 @@ func (pk PubKey) Unwrap() PubKeyInner {
 
 func (p PubKey) Empty() bool {
 	return p.PubKeyInner == nil
-}
-
-var pubKeyMapper = data.NewMapper(PubKey{}).
-	RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519).
-	RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
-
-//-------------------------------------
-
-var _ PubKeyInner = PubKeyEd25519{}
-
-// Implements PubKeyInner
-type PubKeyEd25519 [32]byte
-
-func (pubKey PubKeyEd25519) AssertIsPubKeyInner() {}
-
-func (pubKey PubKeyEd25519) Address() []byte {
-	w, n, err := new(bytes.Buffer), new(int), new(error)
-	wire.WriteBinary(pubKey[:], w, n, err)
-	if *err != nil {
-		PanicCrisis(*err)
-	}
-	// append type byte
-	encodedPubkey := append([]byte{TypeEd25519}, w.Bytes()...)
-	hasher := ripemd160.New()
-	hasher.Write(encodedPubkey) // does not error
-	return hasher.Sum(nil)
-}
-
-func (pubKey PubKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(PubKey{pubKey})
-}
-
-func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
-	// make sure we use the same algorithm to sign
-	sig, ok := sig_.Unwrap().(SignatureEd25519)
-	if !ok {
-		return false
-	}
-	pubKeyBytes := [32]byte(pubKey)
-	sigBytes := [64]byte(sig)
-	return ed25519.Verify(&pubKeyBytes, msg, &sigBytes)
-}
-
-func (p PubKeyEd25519) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p[:])
-}
-
-func (p *PubKeyEd25519) UnmarshalJSON(enc []byte) error {
-	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(p[:], ref)
-	return err
-}
-
-// For use with golang/crypto/nacl/box
-// If error, returns nil.
-func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte {
-	keyCurve25519, pubKeyBytes := new([32]byte), [32]byte(pubKey)
-	ok := extra25519.PublicKeyToCurve25519(keyCurve25519, &pubKeyBytes)
-	if !ok {
-		return nil
-	}
-	return keyCurve25519
-}
-
-func (pubKey PubKeyEd25519) String() string {
-	return Fmt("PubKeyEd25519{%X}", pubKey[:])
-}
-
-// Must return the full bytes in hex.
-// Used for map keying, etc.
-func (pubKey PubKeyEd25519) KeyString() string {
-	return Fmt("%X", pubKey[:])
-}
-
-func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
-	if otherEd, ok := other.Unwrap().(PubKeyEd25519); ok {
-		return bytes.Equal(pubKey[:], otherEd[:])
-	} else {
-		return false
-	}
-}
-
-func (pubKey PubKeyEd25519) Wrap() PubKey {
-	return PubKey{pubKey}
-}
-
-//-------------------------------------
-
-var _ PubKeyInner = PubKeySecp256k1{}
-
-// Implements PubKey.
-// Compressed pubkey (just the x-cord),
-// prefixed with 0x02 or 0x03, depending on the y-cord.
-type PubKeySecp256k1 [33]byte
-
-func (pubKey PubKeySecp256k1) AssertIsPubKeyInner() {}
-
-// Implements Bitcoin style addresses: RIPEMD160(SHA256(pubkey))
-func (pubKey PubKeySecp256k1) Address() []byte {
-	hasherSHA256 := sha256.New()
-	hasherSHA256.Write(pubKey[:]) // does not error
-	sha := hasherSHA256.Sum(nil)
-
-	hasherRIPEMD160 := ripemd160.New()
-	hasherRIPEMD160.Write(sha) // does not error
-	return hasherRIPEMD160.Sum(nil)
-}
-
-func (pubKey PubKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(PubKey{pubKey})
-}
-
-func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
-	// and assert same algorithm to sign and verify
-	sig, ok := sig_.Unwrap().(SignatureSecp256k1)
-	if !ok {
-		return false
-	}
-
-	pub__, err := secp256k1.ParsePubKey(pubKey[:], secp256k1.S256())
-	if err != nil {
-		return false
-	}
-	sig__, err := secp256k1.ParseDERSignature(sig[:], secp256k1.S256())
-	if err != nil {
-		return false
-	}
-	return sig__.Verify(Sha256(msg), pub__)
-}
-
-func (p PubKeySecp256k1) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p[:])
-}
-
-func (p *PubKeySecp256k1) UnmarshalJSON(enc []byte) error {
-	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(p[:], ref)
-	return err
-}
-
-func (pubKey PubKeySecp256k1) String() string {
-	return Fmt("PubKeySecp256k1{%X}", pubKey[:])
-}
-
-// Must return the full bytes in hex.
-// Used for map keying, etc.
-func (pubKey PubKeySecp256k1) KeyString() string {
-	return Fmt("%X", pubKey[:])
-}
-
-func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
-	if otherSecp, ok := other.Unwrap().(PubKeySecp256k1); ok {
-		return bytes.Equal(pubKey[:], otherSecp[:])
-	} else {
-		return false
-	}
-}
-
-func (pubKey PubKeySecp256k1) Wrap() PubKey {
-	return PubKey{pubKey}
 }

--- a/pub_key.go
+++ b/pub_key.go
@@ -12,7 +12,14 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-// PubKeyInner is now the interface itself, use PubKey struct in all code
+/*
+DO NOT USE this interface.
+
+It is public by necessity but should never be used directly
+outside of this package.
+
+Only use the PubKey, never the PubKeyInner
+*/
 type PubKeyInner interface {
 	Address() []byte
 	Bytes() []byte
@@ -30,11 +37,13 @@ func init() {
 		RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
-// PubKey add json serialization to PubKeyInner
+// PubKey should be used instead of an interface in all external packages
+// unless you demand a concrete implementation, then use that directly.
 type PubKey struct {
 	PubKeyInner `json:"unwrap"`
 }
 
+// WrapPubKey goes from concrete implementation to "interface" struct
 func WrapPubKey(pk PubKeyInner) PubKey {
 	if wrap, ok := pk.(PubKey); ok {
 		pk = wrap.Unwrap()
@@ -42,6 +51,7 @@ func WrapPubKey(pk PubKeyInner) PubKey {
 	return PubKey{pk}
 }
 
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
 func (p PubKey) Unwrap() PubKeyInner {
 	pk := p.PubKeyInner
 	for wrap, ok := pk.(PubKey); ok; wrap, ok = pk.(PubKey) {

--- a/pub_key.go
+++ b/pub_key.go
@@ -12,8 +12,8 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-// PubKey is part of Account and Validator.
-type PubKey interface {
+// PubKeyInner is now the interface itself, use PubKey struct in all code
+type PubKeyInner interface {
 	Address() []byte
 	Bytes() []byte
 	KeyString() string
@@ -25,37 +25,45 @@ var pubKeyMapper data.Mapper
 
 // register both public key types with go-data (and thus go-wire)
 func init() {
-	pubKeyMapper = data.NewMapper(PubKeyS{}).
+	pubKeyMapper = data.NewMapper(PubKey{}).
 		RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519).
 		RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
-// PubKeyS add json serialization to PubKey
-type PubKeyS struct {
-	PubKey
+// PubKey add json serialization to PubKeyInner
+type PubKey struct {
+	PubKeyInner
 }
 
-func WrapPubKey(pk PubKey) PubKeyS {
-	for ppk, ok := pk.(PubKeyS); ok; ppk, ok = pk.(PubKeyS) {
-		pk = ppk.PubKey
+func WrapPubKey(pk PubKeyInner) PubKey {
+	if wrap, ok := pk.(PubKey); ok {
+		pk = wrap.Unwrap()
 	}
-	return PubKeyS{pk}
+	return PubKey{pk}
 }
 
-func (p PubKeyS) MarshalJSON() ([]byte, error) {
-	return pubKeyMapper.ToJSON(p.PubKey)
+func (p PubKey) Unwrap() PubKeyInner {
+	pk := p.PubKeyInner
+	for wrap, ok := pk.(PubKey); ok; wrap, ok = pk.(PubKey) {
+		pk = wrap.PubKeyInner
+	}
+	return pk
 }
 
-func (p *PubKeyS) UnmarshalJSON(data []byte) (err error) {
+func (p PubKey) MarshalJSON() ([]byte, error) {
+	return pubKeyMapper.ToJSON(p.PubKeyInner)
+}
+
+func (p *PubKey) UnmarshalJSON(data []byte) (err error) {
 	parsed, err := pubKeyMapper.FromJSON(data)
 	if err == nil && parsed != nil {
-		p.PubKey = parsed.(PubKey)
+		p.PubKeyInner = parsed.(PubKeyInner)
 	}
 	return
 }
 
-func (p PubKeyS) Empty() bool {
-	return p.PubKey == nil
+func (p PubKey) Empty() bool {
+	return p.PubKeyInner == nil
 }
 
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
@@ -65,7 +73,7 @@ func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
 
 //-------------------------------------
 
-// Implements PubKey
+// Implements PubKeyInner
 type PubKeyEd25519 [32]byte
 
 func (pubKey PubKeyEd25519) Address() []byte {
@@ -82,16 +90,12 @@ func (pubKey PubKeyEd25519) Address() []byte {
 }
 
 func (pubKey PubKeyEd25519) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PubKey }{pubKey})
+	return wire.BinaryBytes(PubKey{pubKey})
 }
 
 func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
-	// unwrap if needed
-	if wrap, ok := sig_.(SignatureS); ok {
-		sig_ = wrap.Signature
-	}
 	// make sure we use the same algorithm to sign
-	sig, ok := sig_.(SignatureEd25519)
+	sig, ok := sig_.Unwrap().(SignatureEd25519)
 	if !ok {
 		return false
 	}
@@ -133,7 +137,7 @@ func (pubKey PubKeyEd25519) KeyString() string {
 }
 
 func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
-	if otherEd, ok := other.(PubKeyEd25519); ok {
+	if otherEd, ok := other.Unwrap().(PubKeyEd25519); ok {
 		return bytes.Equal(pubKey[:], otherEd[:])
 	} else {
 		return false
@@ -159,16 +163,12 @@ func (pubKey PubKeySecp256k1) Address() []byte {
 }
 
 func (pubKey PubKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(struct{ PubKey }{pubKey})
+	return wire.BinaryBytes(PubKey{pubKey})
 }
 
 func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
-	// unwrap if needed
-	if wrap, ok := sig_.(SignatureS); ok {
-		sig_ = wrap.Signature
-	}
 	// and assert same algorithm to sign and verify
-	sig, ok := sig_.(SignatureSecp256k1)
+	sig, ok := sig_.Unwrap().(SignatureSecp256k1)
 	if !ok {
 		return false
 	}
@@ -206,7 +206,7 @@ func (pubKey PubKeySecp256k1) KeyString() string {
 }
 
 func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
-	if otherSecp, ok := other.(PubKeySecp256k1); ok {
+	if otherSecp, ok := other.Unwrap().(PubKeySecp256k1); ok {
 		return bytes.Equal(pubKey[:], otherSecp[:])
 	} else {
 		return false

--- a/pub_key.go
+++ b/pub_key.go
@@ -12,79 +12,64 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-/*
-DO NOT USE this interface.
+func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
+	err = wire.ReadBinaryBytes(pubKeyBytes, &pubKey)
+	return
+}
 
-It is public by necessity but should never be used directly
-outside of this package.
+//----------------------------------------
 
-Only use the PubKey, never the PubKeyInner
-*/
+type PubKey struct {
+	PubKeyInner `json:"unwrap"`
+}
+
+// DO NOT USE THIS INTERFACE.
+// You probably want to use PubKey
 type PubKeyInner interface {
+	AssertIsPubKeyInner()
 	Address() []byte
 	Bytes() []byte
 	KeyString() string
 	VerifyBytes(msg []byte, sig Signature) bool
 	Equals(PubKey) bool
+	Wrap() PubKey
 }
 
-var pubKeyMapper data.Mapper
-
-// register both public key types with go-data (and thus go-wire)
-func init() {
-	pubKeyMapper = data.NewMapper(PubKey{}).
-		RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519).
-		RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
+func (pk PubKey) MarshalJSON() ([]byte, error) {
+	return pubKeyMapper.ToJSON(pk.PubKeyInner)
 }
 
-// PubKey should be used instead of an interface in all external packages
-// unless you demand a concrete implementation, then use that directly.
-type PubKey struct {
-	PubKeyInner `json:"unwrap"`
-}
-
-// WrapPubKey goes from concrete implementation to "interface" struct
-func WrapPubKey(pk PubKeyInner) PubKey {
-	if wrap, ok := pk.(PubKey); ok {
-		pk = wrap.Unwrap()
+func (pk *PubKey) UnmarshalJSON(data []byte) (err error) {
+	parsed, err := pubKeyMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		pk.PubKeyInner = parsed.(PubKeyInner)
 	}
-	return PubKey{pk}
+	return
 }
 
 // Unwrap recovers the concrete interface safely (regardless of levels of embeds)
-func (p PubKey) Unwrap() PubKeyInner {
-	pk := p.PubKeyInner
-	for wrap, ok := pk.(PubKey); ok; wrap, ok = pk.(PubKey) {
-		pk = wrap.PubKeyInner
+func (pk PubKey) Unwrap() PubKeyInner {
+	pkI := pk.PubKeyInner
+	for wrap, ok := pkI.(PubKey); ok; wrap, ok = pkI.(PubKey) {
+		pkI = wrap.PubKeyInner
 	}
-	return pk
-}
-
-func (p PubKey) MarshalJSON() ([]byte, error) {
-	return pubKeyMapper.ToJSON(p.PubKeyInner)
-}
-
-func (p *PubKey) UnmarshalJSON(data []byte) (err error) {
-	parsed, err := pubKeyMapper.FromJSON(data)
-	if err == nil && parsed != nil {
-		p.PubKeyInner = parsed.(PubKeyInner)
-	}
-	return
+	return pkI
 }
 
 func (p PubKey) Empty() bool {
 	return p.PubKeyInner == nil
 }
 
-func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
-	err = wire.ReadBinaryBytes(pubKeyBytes, &pubKey)
-	return
-}
+var pubKeyMapper = data.NewMapper(PubKey{}).
+	RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519).
+	RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 
 //-------------------------------------
 
 // Implements PubKeyInner
 type PubKeyEd25519 [32]byte
+
+func (pubKey PubKeyEd25519) AssertIsPubKeyInner() {}
 
 func (pubKey PubKeyEd25519) Address() []byte {
 	w, n, err := new(bytes.Buffer), new(int), new(error)
@@ -154,10 +139,16 @@ func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
 	}
 }
 
+func (pubKey PubKeyEd25519) Wrap() PubKey {
+	return PubKey{pubKey}
+}
+
 //-------------------------------------
 
 // Implements PubKey
 type PubKeySecp256k1 [64]byte
+
+func (pubKey PubKeySecp256k1) AssertIsPubKeyInner() {}
 
 func (pubKey PubKeySecp256k1) Address() []byte {
 	w, n, err := new(bytes.Buffer), new(int), new(error)
@@ -221,4 +212,8 @@ func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
 	} else {
 		return false
 	}
+}
+
+func (pubKey PubKeySecp256k1) Wrap() PubKey {
+	return PubKey{pubKey}
 }

--- a/pub_key.go
+++ b/pub_key.go
@@ -32,7 +32,7 @@ func init() {
 
 // PubKey add json serialization to PubKeyInner
 type PubKey struct {
-	PubKeyInner
+	PubKeyInner `json:"unwrap"`
 }
 
 func WrapPubKey(pk PubKeyInner) PubKey {

--- a/pub_key.go
+++ b/pub_key.go
@@ -26,8 +26,8 @@ var pubKeyMapper data.Mapper
 // register both public key types with go-data (and thus go-wire)
 func init() {
 	pubKeyMapper = data.NewMapper(PubKeyS{}).
-		RegisterInterface(PubKeyEd25519{}, NameEd25519, TypeEd25519).
-		RegisterInterface(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
+		RegisterImplementation(PubKeyEd25519{}, NameEd25519, TypeEd25519).
+		RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
 // PubKeyS add json serialization to PubKey

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -31,7 +31,7 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		var priv PrivKeySecp256k1
 		copy(priv[:], privB)
 
-		pubT := priv.PubKey().(PubKeySecp256k1)
+		pubT := priv.PubKey().Unwrap().(PubKeySecp256k1)
 		pub := pubT[:]
 		addr := priv.PubKey().Address()
 

--- a/secp256k1.go
+++ b/secp256k1.go
@@ -1,0 +1,220 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+
+	"golang.org/x/crypto/ripemd160"
+
+	secp256k1 "github.com/btcsuite/btcd/btcec"
+	cmn "github.com/tendermint/go-common"
+	data "github.com/tendermint/go-data"
+	wire "github.com/tendermint/go-wire"
+)
+
+func init() {
+	privKeyMapper.RegisterImplementation(PrivKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
+	pubKeyMapper.RegisterImplementation(PubKeySecp256k1{}, NameSecp256k1, TypeSecp256k1)
+	sigMapper.RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
+}
+
+//-------------------------------------
+
+var _ PrivKeyInner = PrivKeySecp256k1{}
+
+// Implements PrivKey
+type PrivKeySecp256k1 [32]byte
+
+func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner() {}
+
+func (privKey PrivKeySecp256k1) Bytes() []byte {
+	return wire.BinaryBytes(PrivKey{privKey})
+}
+
+func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
+	priv__, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
+	sig__, err := priv__.Sign(Sha256(msg))
+	if err != nil {
+		cmn.PanicSanity(err)
+	}
+	return SignatureSecp256k1(sig__.Serialize()).Wrap()
+}
+
+func (privKey PrivKeySecp256k1) PubKey() PubKey {
+	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
+	var pub PubKeySecp256k1
+	copy(pub[:], pub__.SerializeCompressed())
+	return pub.Wrap()
+}
+
+func (privKey PrivKeySecp256k1) Equals(other PrivKey) bool {
+	if otherSecp, ok := other.Unwrap().(PrivKeySecp256k1); ok {
+		return bytes.Equal(privKey[:], otherSecp[:])
+	} else {
+		return false
+	}
+}
+
+func (p PrivKeySecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p[:])
+}
+
+func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(p[:], ref)
+	return err
+}
+
+func (privKey PrivKeySecp256k1) String() string {
+	return cmn.Fmt("PrivKeySecp256k1{*****}")
+}
+
+func (privKey PrivKeySecp256k1) Wrap() PrivKey {
+	return PrivKey{privKey}
+}
+
+/*
+// Deterministically generates new priv-key bytes from key.
+func (key PrivKeySecp256k1) Generate(index int) PrivKeySecp256k1 {
+  newBytes := wire.BinarySha256(struct {
+    PrivKey [64]byte
+    Index   int
+  }{key, index})
+  var newKey [64]byte
+  copy(newKey[:], newBytes)
+  return PrivKeySecp256k1(newKey)
+}
+*/
+
+func GenPrivKeySecp256k1() PrivKeySecp256k1 {
+	privKeyBytes := [32]byte{}
+	copy(privKeyBytes[:], CRandBytes(32))
+	priv, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKeyBytes[:])
+	copy(privKeyBytes[:], priv.Serialize())
+	return PrivKeySecp256k1(privKeyBytes)
+}
+
+// NOTE: secret should be the output of a KDF like bcrypt,
+// if it's derived from user input.
+func GenPrivKeySecp256k1FromSecret(secret []byte) PrivKeySecp256k1 {
+	privKey32 := Sha256(secret) // Not Ripemd160 because we want 32 bytes.
+	priv, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey32)
+	privKeyBytes := [32]byte{}
+	copy(privKeyBytes[:], priv.Serialize())
+	return PrivKeySecp256k1(privKeyBytes)
+}
+
+//-------------------------------------
+
+var _ PubKeyInner = PubKeySecp256k1{}
+
+// Implements PubKey.
+// Compressed pubkey (just the x-cord),
+// prefixed with 0x02 or 0x03, depending on the y-cord.
+type PubKeySecp256k1 [33]byte
+
+func (pubKey PubKeySecp256k1) AssertIsPubKeyInner() {}
+
+// Implements Bitcoin style addresses: RIPEMD160(SHA256(pubkey))
+func (pubKey PubKeySecp256k1) Address() []byte {
+	hasherSHA256 := sha256.New()
+	hasherSHA256.Write(pubKey[:]) // does not error
+	sha := hasherSHA256.Sum(nil)
+
+	hasherRIPEMD160 := ripemd160.New()
+	hasherRIPEMD160.Write(sha) // does not error
+	return hasherRIPEMD160.Sum(nil)
+}
+
+func (pubKey PubKeySecp256k1) Bytes() []byte {
+	return wire.BinaryBytes(PubKey{pubKey})
+}
+
+func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
+	// and assert same algorithm to sign and verify
+	sig, ok := sig_.Unwrap().(SignatureSecp256k1)
+	if !ok {
+		return false
+	}
+
+	pub__, err := secp256k1.ParsePubKey(pubKey[:], secp256k1.S256())
+	if err != nil {
+		return false
+	}
+	sig__, err := secp256k1.ParseDERSignature(sig[:], secp256k1.S256())
+	if err != nil {
+		return false
+	}
+	return sig__.Verify(Sha256(msg), pub__)
+}
+
+func (p PubKeySecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(p[:])
+}
+
+func (p *PubKeySecp256k1) UnmarshalJSON(enc []byte) error {
+	var ref []byte
+	err := data.Encoder.Unmarshal(&ref, enc)
+	copy(p[:], ref)
+	return err
+}
+
+func (pubKey PubKeySecp256k1) String() string {
+	return cmn.Fmt("PubKeySecp256k1{%X}", pubKey[:])
+}
+
+// Must return the full bytes in hex.
+// Used for map keying, etc.
+func (pubKey PubKeySecp256k1) KeyString() string {
+	return cmn.Fmt("%X", pubKey[:])
+}
+
+func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
+	if otherSecp, ok := other.Unwrap().(PubKeySecp256k1); ok {
+		return bytes.Equal(pubKey[:], otherSecp[:])
+	} else {
+		return false
+	}
+}
+
+func (pubKey PubKeySecp256k1) Wrap() PubKey {
+	return PubKey{pubKey}
+}
+
+//-------------------------------------
+
+var _ SignatureInner = SignatureSecp256k1{}
+
+// Implements Signature
+type SignatureSecp256k1 []byte
+
+func (sig SignatureSecp256k1) AssertIsSignatureInner() {}
+
+func (sig SignatureSecp256k1) Bytes() []byte {
+	return wire.BinaryBytes(Signature{sig})
+}
+
+func (sig SignatureSecp256k1) IsZero() bool { return len(sig) == 0 }
+
+func (sig SignatureSecp256k1) String() string { return fmt.Sprintf("/%X.../", cmn.Fingerprint(sig[:])) }
+
+func (sig SignatureSecp256k1) Equals(other Signature) bool {
+	if otherEd, ok := other.Unwrap().(SignatureSecp256k1); ok {
+		return bytes.Equal(sig[:], otherEd[:])
+	} else {
+		return false
+	}
+}
+func (sig SignatureSecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(sig)
+}
+
+func (sig *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
+	return data.Encoder.Unmarshal((*[]byte)(sig), enc)
+}
+
+func (sig SignatureSecp256k1) Wrap() Signature {
+	return Signature{sig}
+}

--- a/secp256k1.go
+++ b/secp256k1.go
@@ -10,7 +10,6 @@ import (
 	secp256k1 "github.com/btcsuite/btcd/btcec"
 	cmn "github.com/tendermint/go-common"
 	data "github.com/tendermint/go-data"
-	wire "github.com/tendermint/go-wire"
 )
 
 func init() {
@@ -27,10 +26,6 @@ var _ PrivKeyInner = PrivKeySecp256k1{}
 type PrivKeySecp256k1 [32]byte
 
 func (privKey PrivKeySecp256k1) AssertIsPrivKeyInner() {}
-
-func (privKey PrivKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(PrivKey{privKey})
-}
 
 func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
 	priv__, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
@@ -128,10 +123,6 @@ func (pubKey PubKeySecp256k1) Address() []byte {
 	return hasherRIPEMD160.Sum(nil)
 }
 
-func (pubKey PubKeySecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(PubKey{pubKey})
-}
-
 func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
 	// and assert same algorithm to sign and verify
 	sig, ok := sig_.Unwrap().(SignatureSecp256k1)
@@ -191,10 +182,6 @@ var _ SignatureInner = SignatureSecp256k1{}
 type SignatureSecp256k1 []byte
 
 func (sig SignatureSecp256k1) AssertIsSignatureInner() {}
-
-func (sig SignatureSecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(Signature{sig})
-}
 
 func (sig SignatureSecp256k1) IsZero() bool { return len(sig) == 0 }
 

--- a/signature.go
+++ b/signature.go
@@ -29,7 +29,7 @@ func init() {
 
 // Signature add json serialization to Signature
 type Signature struct {
-	SignatureInner
+	SignatureInner `json:"unwrap"`
 }
 
 func WrapSignature(pk SignatureInner) Signature {

--- a/signature.go
+++ b/signature.go
@@ -31,6 +31,13 @@ type SignatureS struct {
 	Signature
 }
 
+func WrapSignature(sig Signature) SignatureS {
+	for ssig, ok := sig.(SignatureS); ok; ssig, ok = sig.(SignatureS) {
+		sig = ssig.Signature
+	}
+	return SignatureS{sig}
+}
+
 func (p SignatureS) MarshalJSON() ([]byte, error) {
 	return sigMapper.ToJSON(p.Signature)
 }

--- a/signature.go
+++ b/signature.go
@@ -9,8 +9,14 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-// SignatureInner is now the interface itself.
-// Use Signature in all code
+/*
+DO NOT USE this interface.
+
+It is public by necessity but should never be used directly
+outside of this package.
+
+Only use the Signature, never the SignatureInner
+*/
 type SignatureInner interface {
 	Bytes() []byte
 	IsZero() bool
@@ -27,11 +33,13 @@ func init() {
 		RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
-// Signature add json serialization to Signature
+// Signature should be used instead of an interface in all external packages
+// unless you demand a concrete implementation, then use that directly.
 type Signature struct {
 	SignatureInner `json:"unwrap"`
 }
 
+// WrapSignature goes from concrete implementation to "interface" struct
 func WrapSignature(pk SignatureInner) Signature {
 	if wrap, ok := pk.(Signature); ok {
 		pk = wrap.Unwrap()
@@ -39,6 +47,7 @@ func WrapSignature(pk SignatureInner) Signature {
 	return Signature{pk}
 }
 
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
 func (p Signature) Unwrap() SignatureInner {
 	pk := p.SignatureInner
 	for wrap, ok := pk.(Signature); ok; wrap, ok = pk.(Signature) {

--- a/signature.go
+++ b/signature.go
@@ -9,78 +9,63 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-/*
-DO NOT USE this interface.
-
-It is public by necessity but should never be used directly
-outside of this package.
-
-Only use the Signature, never the SignatureInner
-*/
-type SignatureInner interface {
-	Bytes() []byte
-	IsZero() bool
-	String() string
-	Equals(Signature) bool
+func SignatureFromBytes(sigBytes []byte) (sig Signature, err error) {
+	err = wire.ReadBinaryBytes(sigBytes, &sig)
+	return
 }
 
-var sigMapper data.Mapper
+//----------------------------------------
 
-// register both public key types with go-data (and thus go-wire)
-func init() {
-	sigMapper = data.NewMapper(Signature{}).
-		RegisterImplementation(SignatureEd25519{}, NameEd25519, TypeEd25519).
-		RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
-}
-
-// Signature should be used instead of an interface in all external packages
-// unless you demand a concrete implementation, then use that directly.
 type Signature struct {
 	SignatureInner `json:"unwrap"`
 }
 
-// WrapSignature goes from concrete implementation to "interface" struct
-func WrapSignature(pk SignatureInner) Signature {
-	if wrap, ok := pk.(Signature); ok {
-		pk = wrap.Unwrap()
+// DO NOT USE THIS INTERFACE.
+// You probably want to use Signature.
+type SignatureInner interface {
+	AssertIsSignatureInner()
+	Bytes() []byte
+	IsZero() bool
+	String() string
+	Equals(Signature) bool
+	Wrap() Signature
+}
+
+func (sig Signature) MarshalJSON() ([]byte, error) {
+	return sigMapper.ToJSON(sig.SignatureInner)
+}
+
+func (sig *Signature) UnmarshalJSON(data []byte) (err error) {
+	parsed, err := sigMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		sig.SignatureInner = parsed.(SignatureInner)
 	}
-	return Signature{pk}
+	return
 }
 
 // Unwrap recovers the concrete interface safely (regardless of levels of embeds)
-func (p Signature) Unwrap() SignatureInner {
-	pk := p.SignatureInner
+func (sig Signature) Unwrap() SignatureInner {
+	pk := sig.SignatureInner
 	for wrap, ok := pk.(Signature); ok; wrap, ok = pk.(Signature) {
 		pk = wrap.SignatureInner
 	}
 	return pk
 }
 
-func (p Signature) MarshalJSON() ([]byte, error) {
-	return sigMapper.ToJSON(p.SignatureInner)
+func (sig Signature) Empty() bool {
+	return sig.SignatureInner == nil
 }
 
-func (p *Signature) UnmarshalJSON(data []byte) (err error) {
-	parsed, err := sigMapper.FromJSON(data)
-	if err == nil && parsed != nil {
-		p.SignatureInner = parsed.(SignatureInner)
-	}
-	return
-}
-
-func (p Signature) Empty() bool {
-	return p.SignatureInner == nil
-}
-
-func SignatureFromBytes(sigBytes []byte) (sig Signature, err error) {
-	err = wire.ReadBinaryBytes(sigBytes, &sig)
-	return
-}
+var sigMapper = data.NewMapper(Signature{}).
+	RegisterImplementation(SignatureEd25519{}, NameEd25519, TypeEd25519).
+	RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
 
 //-------------------------------------
 
 // Implements Signature
 type SignatureEd25519 [64]byte
+
+func (sig SignatureEd25519) AssertIsSignatureInner() {}
 
 func (sig SignatureEd25519) Bytes() []byte {
 	return wire.BinaryBytes(Signature{sig})
@@ -98,21 +83,27 @@ func (sig SignatureEd25519) Equals(other Signature) bool {
 	}
 }
 
-func (p SignatureEd25519) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p[:])
+func (sig SignatureEd25519) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(sig[:])
 }
 
-func (p *SignatureEd25519) UnmarshalJSON(enc []byte) error {
+func (sig *SignatureEd25519) UnmarshalJSON(enc []byte) error {
 	var ref []byte
 	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(p[:], ref)
+	copy(sig[:], ref)
 	return err
+}
+
+func (sig SignatureEd25519) Wrap() Signature {
+	return Signature{sig}
 }
 
 //-------------------------------------
 
 // Implements Signature
 type SignatureSecp256k1 []byte
+
+func (sig SignatureSecp256k1) AssertIsSignatureInner() {}
 
 func (sig SignatureSecp256k1) Bytes() []byte {
 	return wire.BinaryBytes(Signature{sig})
@@ -129,10 +120,14 @@ func (sig SignatureSecp256k1) Equals(other Signature) bool {
 		return false
 	}
 }
-func (p SignatureSecp256k1) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p)
+func (sig SignatureSecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(sig)
 }
 
-func (p *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
-	return data.Encoder.Unmarshal((*[]byte)(p), enc)
+func (sig *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
+	return data.Encoder.Unmarshal((*[]byte)(sig), enc)
+}
+
+func (sig SignatureSecp256k1) Wrap() Signature {
+	return Signature{sig}
 }

--- a/signature.go
+++ b/signature.go
@@ -62,6 +62,8 @@ var sigMapper = data.NewMapper(Signature{}).
 
 //-------------------------------------
 
+var _ SignatureInner = SignatureEd25519{}
+
 // Implements Signature
 type SignatureEd25519 [64]byte
 
@@ -99,6 +101,8 @@ func (sig SignatureEd25519) Wrap() Signature {
 }
 
 //-------------------------------------
+
+var _ SignatureInner = SignatureSecp256k1{}
 
 // Implements Signature
 type SignatureSecp256k1 []byte

--- a/signature.go
+++ b/signature.go
@@ -22,8 +22,8 @@ var sigMapper data.Mapper
 // register both public key types with go-data (and thus go-wire)
 func init() {
 	sigMapper = data.NewMapper(SignatureS{}).
-		RegisterInterface(SignatureEd25519{}, NameEd25519, TypeEd25519).
-		RegisterInterface(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
+		RegisterImplementation(SignatureEd25519{}, NameEd25519, TypeEd25519).
+		RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
 }
 
 // SignatureS add json serialization to Signature

--- a/signature.go
+++ b/signature.go
@@ -9,56 +9,66 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-// Signature is a part of Txs and consensus Votes.
-type Signature interface {
-	Bytes() []byte
-	IsZero() bool
-	String() string
-	Equals(Signature) bool
-}
-
-var sigMapper data.Mapper
-
-// register both public key types with go-data (and thus go-wire)
-func init() {
-	sigMapper = data.NewMapper(SignatureS{}).
-		RegisterInterface(SignatureEd25519{}, NameEd25519, TypeEd25519).
-		RegisterInterface(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
-}
-
-// SignatureS add json serialization to Signature
-type SignatureS struct {
-	Signature
-}
-
-func (p SignatureS) MarshalJSON() ([]byte, error) {
-	return sigMapper.ToJSON(p.Signature)
-}
-
-func (p *SignatureS) UnmarshalJSON(data []byte) (err error) {
-	parsed, err := sigMapper.FromJSON(data)
-	if err == nil && parsed != nil {
-		p.Signature = parsed.(Signature)
-	}
-	return
-}
-
-func (p SignatureS) Empty() bool {
-	return p.Signature == nil
-}
-
 func SignatureFromBytes(sigBytes []byte) (sig Signature, err error) {
 	err = wire.ReadBinaryBytes(sigBytes, &sig)
 	return
 }
+
+//----------------------------------------
+
+type Signature struct {
+	SignatureInner `json:"unwrap"`
+}
+
+// DO NOT USE THIS INTERFACE.
+// You probably want to use Signature.
+type SignatureInner interface {
+	AssertIsSignatureInner()
+	Bytes() []byte
+	IsZero() bool
+	String() string
+	Equals(Signature) bool
+	Wrap() Signature
+}
+
+func (sig Signature) MarshalJSON() ([]byte, error) {
+	return sigMapper.ToJSON(sig.SignatureInner)
+}
+
+func (sig *Signature) UnmarshalJSON(data []byte) (err error) {
+	parsed, err := sigMapper.FromJSON(data)
+	if err == nil && parsed != nil {
+		sig.SignatureInner = parsed.(SignatureInner)
+	}
+	return
+}
+
+// Unwrap recovers the concrete interface safely (regardless of levels of embeds)
+func (sig Signature) Unwrap() SignatureInner {
+	pk := sig.SignatureInner
+	for wrap, ok := pk.(Signature); ok; wrap, ok = pk.(Signature) {
+		pk = wrap.SignatureInner
+	}
+	return pk
+}
+
+func (sig Signature) Empty() bool {
+	return sig.SignatureInner == nil
+}
+
+var sigMapper = data.NewMapper(Signature{}).
+	RegisterImplementation(SignatureEd25519{}, NameEd25519, TypeEd25519).
+	RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
 
 //-------------------------------------
 
 // Implements Signature
 type SignatureEd25519 [64]byte
 
+func (sig SignatureEd25519) AssertIsSignatureInner() {}
+
 func (sig SignatureEd25519) Bytes() []byte {
-	return wire.BinaryBytes(struct{ Signature }{sig})
+	return wire.BinaryBytes(Signature{sig})
 }
 
 func (sig SignatureEd25519) IsZero() bool { return len(sig) == 0 }
@@ -66,22 +76,26 @@ func (sig SignatureEd25519) IsZero() bool { return len(sig) == 0 }
 func (sig SignatureEd25519) String() string { return fmt.Sprintf("/%X.../", Fingerprint(sig[:])) }
 
 func (sig SignatureEd25519) Equals(other Signature) bool {
-	if otherEd, ok := other.(SignatureEd25519); ok {
+	if otherEd, ok := other.Unwrap().(SignatureEd25519); ok {
 		return bytes.Equal(sig[:], otherEd[:])
 	} else {
 		return false
 	}
 }
 
-func (p SignatureEd25519) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p[:])
+func (sig SignatureEd25519) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(sig[:])
 }
 
-func (p *SignatureEd25519) UnmarshalJSON(enc []byte) error {
+func (sig *SignatureEd25519) UnmarshalJSON(enc []byte) error {
 	var ref []byte
 	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(p[:], ref)
+	copy(sig[:], ref)
 	return err
+}
+
+func (sig SignatureEd25519) Wrap() Signature {
+	return Signature{sig}
 }
 
 //-------------------------------------
@@ -89,8 +103,10 @@ func (p *SignatureEd25519) UnmarshalJSON(enc []byte) error {
 // Implements Signature
 type SignatureSecp256k1 []byte
 
+func (sig SignatureSecp256k1) AssertIsSignatureInner() {}
+
 func (sig SignatureSecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(struct{ Signature }{sig})
+	return wire.BinaryBytes(Signature{sig})
 }
 
 func (sig SignatureSecp256k1) IsZero() bool { return len(sig) == 0 }
@@ -98,16 +114,20 @@ func (sig SignatureSecp256k1) IsZero() bool { return len(sig) == 0 }
 func (sig SignatureSecp256k1) String() string { return fmt.Sprintf("/%X.../", Fingerprint(sig[:])) }
 
 func (sig SignatureSecp256k1) Equals(other Signature) bool {
-	if otherEd, ok := other.(SignatureSecp256k1); ok {
+	if otherEd, ok := other.Unwrap().(SignatureSecp256k1); ok {
 		return bytes.Equal(sig[:], otherEd[:])
 	} else {
 		return false
 	}
 }
-func (p SignatureSecp256k1) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(p)
+func (sig SignatureSecp256k1) MarshalJSON() ([]byte, error) {
+	return data.Encoder.Marshal(sig)
 }
 
-func (p *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
-	return data.Encoder.Unmarshal((*[]byte)(p), enc)
+func (sig *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
+	return data.Encoder.Unmarshal((*[]byte)(sig), enc)
+}
+
+func (sig SignatureSecp256k1) Wrap() Signature {
+	return Signature{sig}
 }

--- a/signature.go
+++ b/signature.go
@@ -1,10 +1,6 @@
 package crypto
 
 import (
-	"bytes"
-	"fmt"
-
-	. "github.com/tendermint/go-common"
 	data "github.com/tendermint/go-data"
 	"github.com/tendermint/go-wire"
 )
@@ -19,6 +15,8 @@ func SignatureFromBytes(sigBytes []byte) (sig Signature, err error) {
 type Signature struct {
 	SignatureInner `json:"unwrap"`
 }
+
+var sigMapper = data.NewMapper(Signature{})
 
 // DO NOT USE THIS INTERFACE.
 // You probably want to use Signature.
@@ -54,84 +52,4 @@ func (sig Signature) Unwrap() SignatureInner {
 
 func (sig Signature) Empty() bool {
 	return sig.SignatureInner == nil
-}
-
-var sigMapper = data.NewMapper(Signature{}).
-	RegisterImplementation(SignatureEd25519{}, NameEd25519, TypeEd25519).
-	RegisterImplementation(SignatureSecp256k1{}, NameSecp256k1, TypeSecp256k1)
-
-//-------------------------------------
-
-var _ SignatureInner = SignatureEd25519{}
-
-// Implements Signature
-type SignatureEd25519 [64]byte
-
-func (sig SignatureEd25519) AssertIsSignatureInner() {}
-
-func (sig SignatureEd25519) Bytes() []byte {
-	return wire.BinaryBytes(Signature{sig})
-}
-
-func (sig SignatureEd25519) IsZero() bool { return len(sig) == 0 }
-
-func (sig SignatureEd25519) String() string { return fmt.Sprintf("/%X.../", Fingerprint(sig[:])) }
-
-func (sig SignatureEd25519) Equals(other Signature) bool {
-	if otherEd, ok := other.Unwrap().(SignatureEd25519); ok {
-		return bytes.Equal(sig[:], otherEd[:])
-	} else {
-		return false
-	}
-}
-
-func (sig SignatureEd25519) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(sig[:])
-}
-
-func (sig *SignatureEd25519) UnmarshalJSON(enc []byte) error {
-	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
-	copy(sig[:], ref)
-	return err
-}
-
-func (sig SignatureEd25519) Wrap() Signature {
-	return Signature{sig}
-}
-
-//-------------------------------------
-
-var _ SignatureInner = SignatureSecp256k1{}
-
-// Implements Signature
-type SignatureSecp256k1 []byte
-
-func (sig SignatureSecp256k1) AssertIsSignatureInner() {}
-
-func (sig SignatureSecp256k1) Bytes() []byte {
-	return wire.BinaryBytes(Signature{sig})
-}
-
-func (sig SignatureSecp256k1) IsZero() bool { return len(sig) == 0 }
-
-func (sig SignatureSecp256k1) String() string { return fmt.Sprintf("/%X.../", Fingerprint(sig[:])) }
-
-func (sig SignatureSecp256k1) Equals(other Signature) bool {
-	if otherEd, ok := other.Unwrap().(SignatureSecp256k1); ok {
-		return bytes.Equal(sig[:], otherEd[:])
-	} else {
-		return false
-	}
-}
-func (sig SignatureSecp256k1) MarshalJSON() ([]byte, error) {
-	return data.Encoder.Marshal(sig)
-}
-
-func (sig *SignatureSecp256k1) UnmarshalJSON(enc []byte) error {
-	return data.Encoder.Unmarshal((*[]byte)(sig), enc)
-}
-
-func (sig SignatureSecp256k1) Wrap() Signature {
-	return Signature{sig}
 }

--- a/signature.go
+++ b/signature.go
@@ -22,11 +22,14 @@ var sigMapper = data.NewMapper(Signature{})
 // You probably want to use Signature.
 type SignatureInner interface {
 	AssertIsSignatureInner()
-	Bytes() []byte
 	IsZero() bool
 	String() string
 	Equals(Signature) bool
 	Wrap() Signature
+}
+
+func (s Signature) Bytes() []byte {
+	return wire.BinaryBytes(s)
 }
 
 func (sig Signature) MarshalJSON() ([]byte, error) {
@@ -51,5 +54,5 @@ func (sig Signature) Unwrap() SignatureInner {
 }
 
 func (sig Signature) Empty() bool {
-	return sig.SignatureInner == nil
+	return sig.SignatureInner == nil || sig.IsZero()
 }

--- a/signature_test.go
+++ b/signature_test.go
@@ -24,7 +24,7 @@ func TestSignAndValidateEd25519(t *testing.T) {
 	// Mutate the signature, just one bit.
 	sigEd := sig.Unwrap().(SignatureEd25519)
 	sigEd[7] ^= byte(0x01)
-	sig = WrapSignature(sigEd)
+	sig = sigEd.Wrap()
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }
@@ -41,7 +41,7 @@ func TestSignAndValidateSecp256k1(t *testing.T) {
 	// Mutate the signature, just one bit.
 	sigEd := sig.Unwrap().(SignatureSecp256k1)
 	sigEd[3] ^= byte(0x01)
-	sig = WrapSignature(sigEd)
+	sig = sigEd.Wrap()
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }
@@ -54,13 +54,13 @@ func TestSignatureEncodings(t *testing.T) {
 		sigName string
 	}{
 		{
-			privKey: WrapPrivKey(GenPrivKeyEd25519()),
+			privKey: GenPrivKeyEd25519().Wrap(),
 			sigSize: ed25519.SignatureSize,
 			sigType: TypeEd25519,
 			sigName: NameEd25519,
 		},
 		{
-			privKey: WrapPrivKey(GenPrivKeySecp256k1()),
+			privKey: GenPrivKeySecp256k1().Wrap(),
 			sigSize: 0, // unknown
 			sigType: TypeSecp256k1,
 			sigName: NameSecp256k1,
@@ -119,10 +119,10 @@ func TestWrapping(t *testing.T) {
 
 	// do some wrapping
 	pubs := []PubKey{
-		WrapPubKey(nil),
-		WrapPubKey(pub),
-		WrapPubKey(WrapPubKey(WrapPubKey(WrapPubKey(pub)))),
-		WrapPubKey(PubKey{PubKey{PubKey{pub}}}),
+		PubKey{nil},
+		pub.Wrap(),
+		pub.Wrap().Wrap().Wrap(),
+		PubKey{PubKey{PubKey{pub}}}.Wrap(),
 	}
 	for _, p := range pubs {
 		_, ok := p.PubKeyInner.(PubKey)
@@ -130,10 +130,10 @@ func TestWrapping(t *testing.T) {
 	}
 
 	sigs := []Signature{
-		WrapSignature(nil),
-		WrapSignature(sig),
-		WrapSignature(WrapSignature(WrapSignature(WrapSignature(sig)))),
-		WrapSignature(Signature{Signature{Signature{sig}}}),
+		Signature{nil},
+		sig.Wrap(),
+		sig.Wrap().Wrap().Wrap(),
+		Signature{Signature{Signature{sig}}}.Wrap(),
 	}
 	for _, s := range sigs {
 		_, ok := s.SignatureInner.(Signature)

--- a/signature_test.go
+++ b/signature_test.go
@@ -107,3 +107,37 @@ func TestSignatureEncodings(t *testing.T) {
 		assert.True(t, strings.HasPrefix(text, tc.sigName))
 	}
 }
+
+func TestWrapping(t *testing.T) {
+	assert := assert.New(t)
+
+	// construct some basic constructs
+	msg := CRandBytes(128)
+	priv := GenPrivKeyEd25519()
+	pub := priv.PubKey()
+	sig := priv.Sign(msg)
+
+	// do some wrapping
+	pubs := []PubKeyS{
+		WrapPubKey(nil),
+		WrapPubKey(pub),
+		WrapPubKey(WrapPubKey(WrapPubKey(WrapPubKey(pub)))),
+		WrapPubKey(PubKeyS{PubKeyS{PubKeyS{pub}}}),
+	}
+	for _, p := range pubs {
+		_, ok := p.PubKey.(PubKeyS)
+		assert.False(ok)
+	}
+
+	sigs := []SignatureS{
+		WrapSignature(nil),
+		WrapSignature(sig),
+		WrapSignature(WrapSignature(WrapSignature(WrapSignature(sig)))),
+		WrapSignature(SignatureS{SignatureS{SignatureS{sig}}}),
+	}
+	for _, s := range sigs {
+		_, ok := s.Signature.(SignatureS)
+		assert.False(ok)
+	}
+
+}

--- a/signature_test.go
+++ b/signature_test.go
@@ -22,9 +22,9 @@ func TestSignAndValidateEd25519(t *testing.T) {
 	assert.True(t, pubKey.VerifyBytes(msg, sig))
 
 	// Mutate the signature, just one bit.
-	sigEd := sig.(SignatureEd25519)
-	sigEd[0] ^= byte(0x01)
-	sig = Signature(sigEd)
+	sigEd := sig.Unwrap().(SignatureEd25519)
+	sigEd[7] ^= byte(0x01)
+	sig = sigEd.Wrap()
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }
@@ -39,28 +39,28 @@ func TestSignAndValidateSecp256k1(t *testing.T) {
 	assert.True(t, pubKey.VerifyBytes(msg, sig))
 
 	// Mutate the signature, just one bit.
-	sigEd := sig.(SignatureSecp256k1)
-	sigEd[0] ^= byte(0x01)
-	sig = Signature(sigEd)
+	sigEd := sig.Unwrap().(SignatureSecp256k1)
+	sigEd[3] ^= byte(0x01)
+	sig = sigEd.Wrap()
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }
 
 func TestSignatureEncodings(t *testing.T) {
 	cases := []struct {
-		privKey PrivKeyS
+		privKey PrivKey
 		sigSize int
 		sigType byte
 		sigName string
 	}{
 		{
-			privKey: PrivKeyS{GenPrivKeyEd25519()},
+			privKey: GenPrivKeyEd25519().Wrap(),
 			sigSize: ed25519.SignatureSize,
 			sigType: TypeEd25519,
 			sigName: NameEd25519,
 		},
 		{
-			privKey: PrivKeyS{GenPrivKeySecp256k1()},
+			privKey: GenPrivKeySecp256k1().Wrap(),
 			sigSize: 0, // unknown
 			sigType: TypeSecp256k1,
 			sigName: NameSecp256k1,
@@ -69,10 +69,10 @@ func TestSignatureEncodings(t *testing.T) {
 
 	for _, tc := range cases {
 		// note we embed them from the beginning....
-		pubKey := PubKeyS{tc.privKey.PubKey()}
+		pubKey := tc.privKey.PubKey()
 
 		msg := CRandBytes(128)
-		sig := SignatureS{tc.privKey.Sign(msg)}
+		sig := tc.privKey.Sign(msg)
 
 		// store as wire
 		bin, err := data.ToWire(sig)
@@ -83,7 +83,7 @@ func TestSignatureEncodings(t *testing.T) {
 		assert.Equal(t, tc.sigType, bin[0])
 
 		// and back
-		sig2 := SignatureS{}
+		sig2 := Signature{}
 		err = data.FromWire(bin, &sig2)
 		require.Nil(t, err, "%+v", err)
 		assert.EqualValues(t, sig, sig2)
@@ -95,7 +95,7 @@ func TestSignatureEncodings(t *testing.T) {
 		assert.True(t, strings.Contains(string(js), tc.sigName))
 
 		// and back
-		sig3 := SignatureS{}
+		sig3 := Signature{}
 		err = data.FromJSON(js, &sig3)
 		require.Nil(t, err, "%+v", err)
 		assert.EqualValues(t, sig, sig3)
@@ -106,4 +106,38 @@ func TestSignatureEncodings(t *testing.T) {
 		require.Nil(t, err, "%+v", err)
 		assert.True(t, strings.HasPrefix(text, tc.sigName))
 	}
+}
+
+func TestWrapping(t *testing.T) {
+	assert := assert.New(t)
+
+	// construct some basic constructs
+	msg := CRandBytes(128)
+	priv := GenPrivKeyEd25519()
+	pub := priv.PubKey()
+	sig := priv.Sign(msg)
+
+	// do some wrapping
+	pubs := []PubKey{
+		PubKey{nil},
+		pub.Wrap(),
+		pub.Wrap().Wrap().Wrap(),
+		PubKey{PubKey{PubKey{pub}}}.Wrap(),
+	}
+	for _, p := range pubs {
+		_, ok := p.PubKeyInner.(PubKey)
+		assert.False(ok)
+	}
+
+	sigs := []Signature{
+		Signature{nil},
+		sig.Wrap(),
+		sig.Wrap().Wrap().Wrap(),
+		Signature{Signature{Signature{sig}}}.Wrap(),
+	}
+	for _, s := range sigs {
+		_, ok := s.SignatureInner.(Signature)
+		assert.False(ok)
+	}
+
 }


### PR DESCRIPTION
I pulled ed25519 and secp256k1 implementations of the `PrivKey`, `PubKey` and `Signature` primitives into their own files.  This makes no changes in the API, but lays the ground-work for adding more algorithms, as the generic structs are in eg. `pub_key.go`, while all algorithm-dependent code is in eg. `ed25519.go`.

I could conceive of another file here (eg. `rsa.go`) or even sub-packages for each algorithm, and in the `main.go` file, one would import the different algorithms one wanted their app to support. (So if you only want secp256k1, it would be easy to compile without ed25519 support).

That is longer-range, for now, more for clarity and defining what exactly needs to be implemented by a new crypto algorithm.

