### PR TITLE
Bcrypt usability

### DIFF
--- a/keys/cryptostore/encoder.go
+++ b/keys/cryptostore/encoder.go
@@ -7,6 +7,20 @@ import (
 	"github.com/tendermint/go-crypto/bcrypt"
 )
 
+const (
+	// BcryptCost is as parameter to increase the resistance of the
+	// encoded keys to brute force password guessing
+	//
+	// Jae: 14 is good today (2016)
+	//
+	// Ethan: loading the key (at each signing) takes a second on my desktop,
+	// this is hard for laptops and deadly for mobile. You can raise it again,
+	// but for now, I will make this usable
+	//
+	// TODO: review value
+	BCryptCost = 12
+)
+
 var (
 	// SecretBox uses the algorithm from NaCL to store secrets securely
 	SecretBox Encoder = secretbox{}
@@ -30,7 +44,7 @@ func (e secretbox) Encrypt(privKey crypto.PrivKey, passphrase string) (saltBytes
 	}
 
 	saltBytes = crypto.CRandBytes(16)
-	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), 14) // TODO parameterize.  14 is good today (2016)
+	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BCryptCost)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Couldn't generate bcrypt key from passphrase.")
 	}
@@ -44,7 +58,7 @@ func (e secretbox) Decrypt(saltBytes []byte, encBytes []byte, passphrase string)
 	// NOTE: Some keys weren't encrypted with a passphrase and hence we have the conditional
 	if passphrase != "" {
 		var key []byte
-		key, err = bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), 14) // TODO parameterize.  14 is good today (2016)
+		key, err = bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BCryptCost)
 		if err != nil {
 			return crypto.PrivKey{}, errors.Wrap(err, "Invalid Passphrase")
 		}


### PR DESCRIPTION
I extracted the cost as a parameter. The current value (14) is nice and secure, but kills the UX. Signing a tx (or returning a bad password error) takes around 1 second just due to the bcrypt decoding of the key on my desktop (i7), slower on other computers. Tests are super slow.

Reducing this to 12 (a factor of 4) makes it much more usable, and I think the security is still quite high. Remember that we decrypt the key every time we use it to avoid keeping it in memory and passing it outside the key manager.

If you think I am destroying the security of our key system, please reject this. 