### PR TITLE
PubKeyFromBytes: return zero value PubKey on error

### DIFF
--- a/pub_key.go
+++ b/pub_key.go
@@ -14,8 +14,10 @@ import (
 )
 
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
-	err = wire.ReadBinaryBytes(pubKeyBytes, &pubKey)
-	return
+	if err := wire.ReadBinaryBytes(pubKeyBytes, &pubKey); err != nil {
+		return PubKey{}, err
+	}
+	return pubKey, nil
 }
 
 //----------------------------------------

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type keyData struct {
@@ -38,4 +39,10 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		assert.Equal(t, pub, pubB, "Expected pub keys to match")
 		assert.Equal(t, addr, addrB, "Expected addresses to match")
 	}
+}
+
+func TestPubKeyInvalidDataProperReturnsEmpty(t *testing.T) {
+	pk, err := PubKeyFromBytes([]byte("foo"))
+	require.NotNil(t, err, "expecting a non-nil error")
+	require.True(t, pk.Empty(), "expecting an empty public key on error")
 }


### PR DESCRIPTION
Fixes https://github.com/tendermint/go-crypto/issues/48.

This previously skewed up my fuzzing tests so ensure
that on error we return the zero value PubKey.