### PR TITLE
CRandHex: fix up doc to mention length of digits

### DIFF
--- a/random.go
+++ b/random.go
@@ -44,7 +44,10 @@ func CRandBytes(numBytes int) []byte {
 	return b
 }
 
-// RandHex(24) gives 96 bits of randomness, strong enough for most purposes.
+// CRandHex returns a hex encoded string that's floor(numDigits/2) * 2 long.
+//
+// Note: CRandHex(24) gives 96 bits of randomness that
+// are usually strong enough for most purposes.
 func CRandHex(numDigits int) string {
 	return hex.EncodeToString(CRandBytes(numDigits / 2))
 }


### PR DESCRIPTION
The previous doc seemed misleading and was out of date i.e.
RandHex(24)
not
CRandHex.

Anyways provide a doc of what the function does in relation to
the length of digits of the hex value returned i.e.
  floor(numDigits / 2) * 2
so the even lowest number
  e.g:
  * len(CRandHex(5)) = 4
  * len(CRandHex(4)) = 4