### PR TITLE
PrivKey*: fix UnmarshalJSON to return err ASAP avoiding unconditional copy call

### DIFF
--- a/priv_key.go
+++ b/priv_key.go
@@ -85,9 +85,11 @@ func (p PrivKeyEd25519) MarshalJSON() ([]byte, error) {
 
 func (p *PrivKeyEd25519) UnmarshalJSON(enc []byte) error {
 	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
+	if err := data.Encoder.Unmarshal(&ref, enc); err != nil {
+		return err
+	}
 	copy(p[:], ref)
-	return err
+	return nil
 }
 
 func (privKey PrivKeyEd25519) ToCurve25519() *[32]byte {
@@ -174,9 +176,11 @@ func (p PrivKeySecp256k1) MarshalJSON() ([]byte, error) {
 
 func (p *PrivKeySecp256k1) UnmarshalJSON(enc []byte) error {
 	var ref []byte
-	err := data.Encoder.Unmarshal(&ref, enc)
+	if err := data.Encoder.Unmarshal(&ref, enc); err != nil {
+		return err
+	}
 	copy(p[:], ref)
-	return err
+	return nil
 }
 
 func (privKey PrivKeySecp256k1) String() string {


### PR DESCRIPTION
Noticed while reading through
https://github.com/tendermint/tendermint/pull/1048/files#diff-072f7b0dc4657b530eec2f4a5ca94e5bR82

that we weren't checking for zeroness, but then the UnmarshalJSON
methods of:
* PrivKeyEd25519
* PrivKeySecp256k1
would return the error but unconditionally invoked copy even
on zeroed bytes, hence return early if we encounter an error
and only invoke copy if we've passed.