### PR TITLE
Add support for bech32cosmos

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3d9c9b0bc44ebdc7448e4fad6476df19f0bc0fa17b4e78344901bafbe34d8480
-updated: 2018-02-12T12:56:37.252249+01:00
+updated: 2018-02-20T19:43:29.661264458+01:00
 imports:
 - name: github.com/btcsuite/btcd
   version: 2e60448ffcc6bf78332d1fe590260095f554dd78
@@ -26,7 +26,7 @@ imports:
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-stack/stack
-  version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
+  version: 259ab82a6cad3992b4e21ff5cac294ccb06474bc
 - name: github.com/gogo/protobuf
   version: 1adfc126b41513cc696b209667c8656ea7aac67c
   subpackages:
@@ -44,7 +44,7 @@ imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/syndtr/goleveldb
-  version: b89cc31ef7977104127d34c1bd31ebd1a9db2199
+  version: 34011bf325bce385408353a30b101fe5e923eb6e
   subpackages:
   - leveldb
   - leveldb/cache
@@ -72,7 +72,7 @@ imports:
   - db
   - log
 - name: golang.org/x/crypto
-  version: edd5e9b0879d13ee6970a50153d85b8fec9f7686
+  version: 95a4943f35d008beabde8c11e5075a1b714e6419
   subpackages:
   - bcrypt
   - blowfish

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 95b2c2a089ca7242bc52c3bfe5a0286ae68201197f7f5855dd6e8f2ee3974068
-updated: 2018-02-02T23:50:03.327504896-05:00
+hash: 3d9c9b0bc44ebdc7448e4fad6476df19f0bc0fa17b4e78344901bafbe34d8480
+updated: 2018-02-12T12:56:37.252249+01:00
 imports:
 - name: github.com/btcsuite/btcd
   version: 2e60448ffcc6bf78332d1fe590260095f554dd78
@@ -9,6 +9,10 @@ imports:
   version: 501929d3d046174c3d39f0ea54ece471aa17238c
   subpackages:
   - base58
+- name: github.com/cosmos/bech32cosmos
+  version: e9ace91a8b2c9cfea3988a3cc8dd19ce60e7103e
+  subpackages:
+  - go
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
@@ -62,7 +66,7 @@ imports:
 - name: github.com/tendermint/go-wire
   version: dec83f641903b22f039da3974607859715d0377e
 - name: github.com/tendermint/tmlibs
-  version: 1d7fc78ea171587e9e63da566d3da1b127bfd14c
+  version: 52ce4c20f8bc9b6da5fc1274bcce27c0b9dd738a
   subpackages:
   - common
   - db

--- a/glide.lock
+++ b/glide.lock
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - base58
 - name: github.com/cosmos/bech32cosmos
-  version: e9ace91a8b2c9cfea3988a3cc8dd19ce60e7103e
+  version: bfcba472e4278e3ab64a61a1dbba76ccbdc81ceb
   subpackages:
   - go
 - name: github.com/davecgh/go-spew

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3d9c9b0bc44ebdc7448e4fad6476df19f0bc0fa17b4e78344901bafbe34d8480
-updated: 2018-02-20T19:43:29.661264458+01:00
+updated: 2018-02-20T19:47:26.54587177+01:00
 imports:
 - name: github.com/btcsuite/btcd
   version: 2e60448ffcc6bf78332d1fe590260095f554dd78

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/tendermint/go-crypto
 import:
-- package: github.com/cosmos/bech32cosmos
+- package: github.com/cosmos/bech32cosmos/go
 - package: github.com/btcsuite/btcd
   subpackages:
   - btcec

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/tendermint/go-crypto
 import:
+- package: github.com/cosmos/bech32cosmos
 - package: github.com/btcsuite/btcd
   subpackages:
   - btcec

--- a/priv_key.go
+++ b/priv_key.go
@@ -47,7 +47,7 @@ func (privKey PrivKeyEd25519) Sign(msg []byte) Signature {
 func (privKey PrivKeyEd25519) PubKey() PubKey {
 	privKeyBytes := [64]byte(privKey)
 	pubBytes := *ed25519.MakePublicKey(&privKeyBytes)
-	return PubKeyEd25519(pubBytes)
+	return PubKeyEd25519{pubBytes, ""}
 }
 
 // Equals - you probably don't need to use this.
@@ -132,7 +132,7 @@ func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
 func (privKey PrivKeySecp256k1) PubKey() PubKey {
 	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
 	var pub PubKeySecp256k1
-	copy(pub[:], pub__.SerializeCompressed())
+	copy(pub.data[:], pub__.SerializeCompressed())
 	return pub
 }
 

--- a/priv_key.go
+++ b/priv_key.go
@@ -131,8 +131,8 @@ func (privKey PrivKeySecp256k1) Sign(msg []byte) Signature {
 
 func (privKey PrivKeySecp256k1) PubKey() PubKey {
 	_, pub__ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), privKey[:])
-	var pub PubKeySecp256k1
-	copy(pub.data[:], pub__.SerializeCompressed())
+	pub := PubKeySecp256k1{}
+	copy(pub.Data[:], pub__.SerializeCompressed())
 	return pub
 }
 

--- a/pub_key.go
+++ b/pub_key.go
@@ -31,7 +31,10 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("%s is not CSMSADDR the Cosmos Address identifier", readable)
 	}
 
-	cdc.UnmarshalBinary(deserialized, a)
+	err = cdc.UnmarshalBinary(deserialized, a)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -41,7 +44,9 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	bech, err := bech32cosmos.Encode("CSMSADDR", marshaled)
+	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
+
+	bech, err := bech32cosmos.Encode("CSMSADDR", conv)
 	if err != nil {
 		return nil, err
 	}
@@ -51,13 +56,38 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 func (a *Address) String() string {
 	marshaled, err := cdc.MarshalBinary(a)
 	if err != nil {
-		return err.Error()
+		return "go-wire err:" + err.Error()
 	}
-	bech, err := bech32cosmos.Encode("CSMSADDR", marshaled)
+	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
+
+	bech, err := bech32cosmos.Encode("CSMSADDR", conv)
 	if err != nil {
-		return err.Error()
+		return "bech32cosmos err:" + err.Error()
 	}
 	return bech
+}
+
+func (a *Address) FromString(str string) error {
+	readable, deserialized, err := bech32cosmos.Decode(str)
+	if err != nil {
+		return err
+	}
+	if strings.ToUpper(readable) != "CSMSADDR" {
+		return fmt.Errorf("%s is not CSMSADDR the Cosmos Address identifier", readable)
+	}
+
+	deserialized, err = bech32cosmos.ConvertBits(deserialized, 5, 8, true)
+
+	err = cdc.UnmarshalBinary(deserialized, a)
+
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey PubKey, err error) {
@@ -123,7 +153,9 @@ func (pubKey PubKeyEd25519) String() string {
 	if err != nil {
 		return err.Error()
 	}
-	bech, err := bech32cosmos.Encode("CSMSPUB", marshaled)
+	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
+
+	bech, err := bech32cosmos.Encode("CSMSPUB", conv)
 	if err != nil {
 		return err.Error()
 	}
@@ -189,7 +221,9 @@ func (pubKey PubKeySecp256k1) String() string {
 	if err != nil {
 		return err.Error()
 	}
-	bech, err := bech32cosmos.Encode("CSMSPUB", marshaled)
+	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
+
+	bech, err := bech32cosmos.Encode("CSMSPUB", conv)
 	if err != nil {
 		return err.Error()
 	}

--- a/pub_key.go
+++ b/pub_key.go
@@ -27,15 +27,21 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	if strings.ToUpper(readable) != "COSADDR" {
-		return fmt.Errorf("%s is not COSADDR the Cosmos Address identifier", readable)
+	if strings.ToUpper(readable) != "CSMSADDR" {
+		return fmt.Errorf("%s is not CSMSADDR the Cosmos Address identifier", readable)
 	}
-	*a = Address{deserialized}
+
+	cdc.UnmarshalBinary(deserialized, a)
 	return nil
 }
 
 func (a *Address) MarshalJSON() ([]byte, error) {
-	bech, err := bech32cosmos.Encode("COSADDR", a.Bytes())
+
+	marshaled, err := cdc.MarshalBinary(a)
+	if err != nil {
+		return nil, err
+	}
+	bech, err := bech32cosmos.Encode("CSMSADDR", marshaled)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +49,11 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 }
 
 func (a *Address) String() string {
-	bech, err := bech32cosmos.Encode("COSADDR", a.Bytes())
+	marshaled, err := cdc.MarshalBinary(a)
+	if err != nil {
+		return err.Error()
+	}
+	bech, err := bech32cosmos.Encode("CSMSADDR", marshaled)
 	if err != nil {
 		return err.Error()
 	}
@@ -109,7 +119,11 @@ func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte {
 }
 
 func (pubKey PubKeyEd25519) String() string {
-	bech, err := bech32cosmos.Encode("COSPUBKEY", pubKey[:])
+	marshaled, err := cdc.MarshalBinary(pubKey)
+	if err != nil {
+		return err.Error()
+	}
+	bech, err := bech32cosmos.Encode("CSMSPUB", marshaled)
 	if err != nil {
 		return err.Error()
 	}
@@ -171,7 +185,15 @@ func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
 }
 
 func (pubKey PubKeySecp256k1) String() string {
-	return fmt.Sprintf("PubKeySecp256k1{%X}", pubKey[:])
+	marshaled, err := cdc.MarshalBinary(pubKey)
+	if err != nil {
+		return err.Error()
+	}
+	bech, err := bech32cosmos.Encode("CSMSPUB", marshaled)
+	if err != nil {
+		return err.Error()
+	}
+	return bech
 }
 
 func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {

--- a/pub_key.go
+++ b/pub_key.go
@@ -44,11 +44,11 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 
-	readable := "CSMSADDR"
+	readable := "csvsaddr"
 	if a.humanReadable != "" {
 		readable = a.humanReadable
 	}
-	bech, err := bech32cosmos.Encode(readable, conv)
+	bech, err := bech32cosmos.Encode(strings.ToLower(readable), conv)
 
 	if err != nil {
 		return nil, err
@@ -63,7 +63,12 @@ func (a *Address) String() string {
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 
-	bech, err := bech32cosmos.Encode("CSMSADDR", conv)
+	readable := "csmsaddr"
+	if a.humanReadable != "" {
+		readable = a.humanReadable
+	}
+	bech, err := bech32cosmos.Encode(strings.ToLower(readable), conv)
+
 	if err != nil {
 		return "bech32cosmos err:" + err.Error()
 	}
@@ -113,7 +118,7 @@ var _ PubKey = PubKeyEd25519{}
 
 // Implements PubKeyInner
 type PubKeyEd25519 struct {
-	data          [32]byte
+	Data          [32]byte
 	humanReadable string
 }
 
@@ -138,7 +143,7 @@ func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
 	if !ok {
 		return false
 	}
-	pubKeyBytes := [32]byte(pubKey.data)
+	pubKeyBytes := [32]byte(pubKey.Data)
 	sigBytes := [64]byte(sig)
 	return ed25519.Verify(&pubKeyBytes, msg, &sigBytes)
 }
@@ -146,7 +151,7 @@ func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
 // For use with golang/crypto/nacl/box
 // If error, returns nil.
 func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte {
-	keyCurve25519, pubKeyBytes := new([32]byte), [32]byte(pubKey.data)
+	keyCurve25519, pubKeyBytes := new([32]byte), [32]byte(pubKey.Data)
 	ok := extra25519.PublicKeyToCurve25519(keyCurve25519, &pubKeyBytes)
 	if !ok {
 		return nil
@@ -161,12 +166,12 @@ func (pubKey PubKeyEd25519) String() string {
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 
-	readable := "CSMSPUB"
+	readable := "csmspub"
 	if pubKey.humanReadable != "" {
 		readable = pubKey.humanReadable
 	}
 
-	bech, err := bech32cosmos.Encode(readable, conv)
+	bech, err := bech32cosmos.Encode(strings.ToLower(readable), conv)
 	if err != nil {
 		return err.Error()
 	}
@@ -195,7 +200,7 @@ func (pubKey *PubKeyEd25519) FromString(str string) error {
 
 func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
 	if otherEd, ok := other.(PubKeyEd25519); ok {
-		return bytes.Equal(pubKey.data[:], otherEd.data[:])
+		return bytes.Equal(pubKey.Data[:], otherEd.Data[:])
 	} else {
 		return false
 	}
@@ -209,7 +214,7 @@ var _ PubKey = PubKeySecp256k1{}
 // Compressed pubkey (just the x-cord),
 // prefixed with 0x02 or 0x03, depending on the y-cord.
 type PubKeySecp256k1 struct {
-	data          [33]byte
+	Data          [33]byte
 	humanReadable string
 }
 
@@ -239,7 +244,7 @@ func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
 		return false
 	}
 
-	pub__, err := secp256k1.ParsePubKey(pubKey.Bytes(), secp256k1.S256())
+	pub__, err := secp256k1.ParsePubKey(pubKey.Data[:], secp256k1.S256())
 	if err != nil {
 		return false
 	}
@@ -257,12 +262,12 @@ func (pubKey PubKeySecp256k1) String() string {
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 
-	readable := "CSMSPUB"
+	readable := "csmspub"
 	if pubKey.humanReadable != "" {
 		readable = pubKey.humanReadable
 	}
 
-	bech, err := bech32cosmos.Encode(readable, conv)
+	bech, err := bech32cosmos.Encode(strings.ToLower(readable), conv)
 	if err != nil {
 		return err.Error()
 	}
@@ -283,7 +288,6 @@ func (pubKey *PubKeySecp256k1) FromString(str string) error {
 	}
 
 	err = cdc.UnmarshalBinary(converted, pubKey)
-
 	if err != nil {
 		return err
 	}

--- a/pub_key.go
+++ b/pub_key.go
@@ -3,7 +3,6 @@ package crypto
 import (
 	"bytes"
 	"crypto/sha256"
-	"fmt"
 	"strings"
 
 	"github.com/cosmos/bech32cosmos/go"
@@ -80,9 +79,8 @@ func (a *Address) FromString(str string) error {
 	if err != nil {
 		return err
 	}
-	if strings.ToUpper(readable) != "CSMSADDR" {
-		return fmt.Errorf("%s is not CSMSADDR the Cosmos Address identifier", readable)
-	}
+
+	a.humanReadable = readable
 
 	deserialized, err = bech32cosmos.ConvertBits(deserialized, 5, 8, false)
 

--- a/pub_key.go
+++ b/pub_key.go
@@ -181,11 +181,11 @@ func (pubKey *PubKeyEd25519) FromString(str string) error {
 	pubKey.humanReadable = readable
 	deserialized, err = bech32cosmos.ConvertBits(deserialized, 5, 8, false)
 
-	err = cdc.UnmarshalBinary(deserialized, pubKey)
-
 	if err != nil {
 		return err
 	}
+
+	err = cdc.UnmarshalBinary(deserialized, pubKey)
 
 	if err != nil {
 		return err
@@ -277,6 +277,10 @@ func (pubKey *PubKeySecp256k1) FromString(str string) error {
 
 	pubKey.humanReadable = readable
 	converted, err := bech32cosmos.ConvertBits(deserialized, 5, 8, false)
+
+	if err != nil {
+		return err
+	}
 
 	err = cdc.UnmarshalBinary(converted, pubKey)
 

--- a/pub_key.go
+++ b/pub_key.go
@@ -59,7 +59,7 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 func (a *Address) String() string {
 	marshaled, err := cdc.MarshalBinary(a)
 	if err != nil {
-		return "go-wire err:" + err.Error()
+		panic("go-wire err:" + err.Error())
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 
@@ -70,7 +70,7 @@ func (a *Address) String() string {
 	bech, err := bech32cosmos.Encode(strings.ToLower(readable), conv)
 
 	if err != nil {
-		return "bech32cosmos err:" + err.Error()
+		panic("bech32cosmos err:" + err.Error())
 	}
 	return bech
 }
@@ -162,7 +162,7 @@ func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte {
 func (pubKey PubKeyEd25519) String() string {
 	marshaled, err := cdc.MarshalBinary(pubKey)
 	if err != nil {
-		return err.Error()
+		panic(err.Error())
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 
@@ -258,7 +258,7 @@ func (pubKey PubKeySecp256k1) VerifyBytes(msg []byte, sig_ Signature) bool {
 func (pubKey PubKeySecp256k1) String() string {
 	marshaled, err := cdc.MarshalBinary(pubKey)
 	if err != nil {
-		return err.Error()
+		panic(err.Error())
 	}
 	conv, err := bech32cosmos.ConvertBits(marshaled, 8, 5, true)
 

--- a/pub_key.go
+++ b/pub_key.go
@@ -108,6 +108,7 @@ type PubKey interface {
 	Bytes() []byte
 	VerifyBytes(msg []byte, sig Signature) bool
 	Equals(PubKey) bool
+	VerifyReadable(readable string) bool
 }
 
 //-------------------------------------
@@ -204,6 +205,10 @@ func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
 	}
 }
 
+func (pubkey PubKeyEd25519) VerifyReadable(readable string) bool {
+	return pubkey.humanReadable == readable
+}
+
 //-------------------------------------
 
 var _ PubKey = PubKeySecp256k1{}
@@ -297,4 +302,8 @@ func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
 	} else {
 		return false
 	}
+}
+
+func (pubkey PubKeySecp256k1) VerifyReadable(readable string) bool {
+	return pubkey.humanReadable == readable
 }

--- a/pub_key.go
+++ b/pub_key.go
@@ -76,7 +76,7 @@ func (a *Address) FromString(str string) error {
 		return fmt.Errorf("%s is not CSMSADDR the Cosmos Address identifier", readable)
 	}
 
-	deserialized, err = bech32cosmos.ConvertBits(deserialized, 5, 8, true)
+	deserialized, err = bech32cosmos.ConvertBits(deserialized, 5, 8, false)
 
 	err = cdc.UnmarshalBinary(deserialized, a)
 
@@ -162,6 +162,29 @@ func (pubKey PubKeyEd25519) String() string {
 	return bech
 }
 
+func (pubKey *PubKeyEd25519) FromString(str string) error {
+	readable, deserialized, err := bech32cosmos.Decode(str)
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(readable) != "csmspub" {
+		return fmt.Errorf("%s is not csmspub the Cosmos Public Key identifier", readable)
+	}
+
+	deserialized, err = bech32cosmos.ConvertBits(deserialized, 5, 8, false)
+
+	err = cdc.UnmarshalBinary(deserialized, pubKey)
+
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
 	if otherEd, ok := other.(PubKeyEd25519); ok {
 		return bytes.Equal(pubKey[:], otherEd[:])
@@ -230,6 +253,28 @@ func (pubKey PubKeySecp256k1) String() string {
 	return bech
 }
 
+func (pubKey *PubKeySecp256k1) FromString(str string) error {
+	readable, deserialized, err := bech32cosmos.Decode(str)
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(readable) != "csmspub" {
+		return fmt.Errorf("%s is not csmspub the Cosmos Public Key identifier", readable)
+	}
+
+	converted, err := bech32cosmos.ConvertBits(deserialized, 5, 8, false)
+
+	err = cdc.UnmarshalBinary(converted, pubKey)
+
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
 func (pubKey PubKeySecp256k1) Equals(other PubKey) bool {
 	if otherSecp, ok := other.(PubKeySecp256k1); ok {
 		return bytes.Equal(pubKey[:], otherSecp[:])

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -32,7 +32,7 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		privB, _ := hex.DecodeString(d.priv)
 		pubB, _ := hex.DecodeString(d.pub)
 		addrBbz, _, _ := base58.CheckDecode(d.addr)
-		addrB := Address{addrBbz}
+		addrB := Address{addrBbz, ""}
 		addrDecoded := Address{}
 		err := addrDecoded.FromString(d.bech32addr)
 		if err != nil {

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -48,7 +48,7 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pub := pubT[:]
+		pub := pubT.Bytes()
 
 		addr := priv.PubKey().Address()
 		assert.Equal(t, pubT.String(), d.bech32pub)

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -28,7 +28,7 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		privB, _ := hex.DecodeString(d.priv)
 		pubB, _ := hex.DecodeString(d.pub)
 		addrBbz, _, _ := base58.CheckDecode(d.addr)
-		addrB := Address(addrBbz)
+		addrB := Address{addrBbz}
 
 		var priv PrivKeySecp256k1
 		copy(priv[:], privB)

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -14,6 +14,7 @@ type keyData struct {
 	pub        string
 	addr       string
 	bech32addr string
+	bech32pub  string
 }
 
 var secpDataTable = []keyData{
@@ -22,6 +23,7 @@ var secpDataTable = []keyData{
 		pub:        "02950e1cdfcb133d6024109fd489f734eeb4502418e538c28481f22bce276f248c",
 		addr:       "1CKZ9Nx4zgds8tU7nJHotKSDr4a9bYJCa3",
 		bech32addr: "csmsaddr:cklnrf3g0s4mg25tu6termrk8egltfyme4q7sg3h9myxnv",
+		bech32pub:  "csmspub:ucfk4sszj58peh7tzv7kqfqsnl2gnae5a669qfqcu5uv9pyp7g4uufm0yjxqpj95k8",
 	},
 }
 
@@ -40,8 +42,17 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		copy(priv[:], privB)
 
 		pubT := priv.PubKey().(PubKeySecp256k1)
+		pubDeserialized := priv.PubKey().(PubKeySecp256k1)
+		err = pubDeserialized.FromString(d.bech32pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		pub := pubT[:]
+
 		addr := priv.PubKey().Address()
+		assert.Equal(t, pubT.String(), d.bech32pub)
+		assert.Equal(t, pubT, pubDeserialized)
 		assert.Equal(t, addr.String(), d.bech32addr)
 		assert.Equal(t, addr, addrDecoded)
 		assert.Equal(t, pub, pubB, "Expected pub keys to match")

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -10,16 +10,18 @@ import (
 )
 
 type keyData struct {
-	priv string
-	pub  string
-	addr string
+	priv       string
+	pub        string
+	addr       string
+	bech32addr string
 }
 
 var secpDataTable = []keyData{
 	{
-		priv: "a96e62ed3955e65be32703f12d87b6b5cf26039ecfa948dc5107a495418e5330",
-		pub:  "02950e1cdfcb133d6024109fd489f734eeb4502418e538c28481f22bce276f248c",
-		addr: "1CKZ9Nx4zgds8tU7nJHotKSDr4a9bYJCa3",
+		priv:       "a96e62ed3955e65be32703f12d87b6b5cf26039ecfa948dc5107a495418e5330",
+		pub:        "02950e1cdfcb133d6024109fd489f734eeb4502418e538c28481f22bce276f248c",
+		addr:       "1CKZ9Nx4zgds8tU7nJHotKSDr4a9bYJCa3",
+		bech32addr: "csmsaddr:cklnrf3g0s4mg25tu6termrk8egltfyme4q7sg3h9myxnv",
 	},
 }
 
@@ -29,14 +31,19 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		pubB, _ := hex.DecodeString(d.pub)
 		addrBbz, _, _ := base58.CheckDecode(d.addr)
 		addrB := Address{addrBbz}
-
+		addrDecoded := Address{}
+		err := addrDecoded.FromString(d.bech32addr)
+		if err != nil {
+			t.Fatal(err)
+		}
 		var priv PrivKeySecp256k1
 		copy(priv[:], privB)
 
 		pubT := priv.PubKey().(PubKeySecp256k1)
 		pub := pubT[:]
 		addr := priv.PubKey().Address()
-
+		assert.Equal(t, addr.String(), d.bech32addr)
+		assert.Equal(t, addr, addrDecoded)
 		assert.Equal(t, pub, pubB, "Expected pub keys to match")
 		assert.Equal(t, addr, addrB, "Expected addresses to match")
 	}

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -56,6 +56,46 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 	}
 }
 
+var ed25519DataTable = []keyData{
+	{
+		priv:       "a96e62ed3955e65be32703f12d87b6b5cf26039ecfa948dc5107a495418e5330",
+		pub:        "328eaf59a52d39cf0fcb8e9fd431788c7731731400500b7f3c011463f8d55d3ffd8aeba1",
+		bech32addr: "csmsaddr:cklnrf3gqh9lwgjh7e56u5k9tl6l7jqz5h42c3smqsdl70",
+		bech32pub:  "csmspub:x2827kd995uu7r7t360agvtc33mnzuc5qpgqkleuqy2x87x4t5llmzht5yn5j4az",
+	},
+}
+
+func TestPubKeyEd25519Address(t *testing.T) {
+	for _, d := range ed25519DataTable {
+		privB, _ := hex.DecodeString(d.priv)
+		pubB, _ := hex.DecodeString(d.pub)
+		addrDecoded := Address{}
+		err := addrDecoded.FromString(d.bech32addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var priv PrivKeyEd25519
+		copy(priv[:], privB)
+
+		pubT := priv.PubKey().(PubKeyEd25519)
+		pubT.humanReadable = "csmspub"
+		pubDeserialized := priv.PubKey().(PubKeyEd25519)
+		err = pubDeserialized.FromString(d.bech32pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pub := pubT.Bytes()
+
+		addr := priv.PubKey().Address()
+		assert.Equal(t, pubT.String(), d.bech32pub)
+		assert.Equal(t, pubT, pubDeserialized)
+		assert.Equal(t, addr.String(), d.bech32addr)
+		assert.Equal(t, addr, addrDecoded)
+		assert.Equal(t, pub, pubB, "Expected pub keys to match")
+	}
+}
+
 func TestPubKeyInvalidDataProperReturnsEmpty(t *testing.T) {
 	pk, err := PubKeyFromBytes([]byte("foo"))
 	require.NotNil(t, err, "expecting a non-nil error")

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -51,7 +51,7 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		assert.Equal(t, pubT.String(), d.bech32pub)
 		assert.Equal(t, pubT, pubDeserialized)
 		assert.Equal(t, addr.String(), d.bech32addr)
-		assert.Equal(t, addr, addrDecoded)
+		assert.Equal(t, addr.HexBytes, addrDecoded.HexBytes)
 		assert.Equal(t, pub, pubB, "Expected pub keys to match")
 	}
 }
@@ -91,7 +91,7 @@ func TestPubKeyEd25519Address(t *testing.T) {
 		assert.Equal(t, pubT.String(), d.bech32pub)
 		assert.Equal(t, pubT, pubDeserialized)
 		assert.Equal(t, addr.String(), d.bech32addr)
-		assert.Equal(t, addr, addrDecoded)
+		assert.Equal(t, addr.HexBytes, addrDecoded.HexBytes)
 		assert.Equal(t, pub, pubB, "Expected pub keys to match")
 	}
 }

--- a/pub_key_test.go
+++ b/pub_key_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,9 +19,8 @@ type keyData struct {
 var secpDataTable = []keyData{
 	{
 		priv:       "a96e62ed3955e65be32703f12d87b6b5cf26039ecfa948dc5107a495418e5330",
-		pub:        "02950e1cdfcb133d6024109fd489f734eeb4502418e538c28481f22bce276f248c",
-		addr:       "1CKZ9Nx4zgds8tU7nJHotKSDr4a9bYJCa3",
-		bech32addr: "csmsaddr:cklnrf3g0s4mg25tu6termrk8egltfyme4q7sg3h9myxnv",
+		pub:        "e6136ac202950e1cdfcb133d6024109fd489f734eeb4502418e538c28481f22bce276f248c",
+		bech32addr: "csmsaddr:cklnrf3gj4ddtx5uvpchf3r8qzfdmgc2pcm9kknzqwc3th",
 		bech32pub:  "csmspub:ucfk4sszj58peh7tzv7kqfqsnl2gnae5a669qfqcu5uv9pyp7g4uufm0yjxqpj95k8",
 	},
 }
@@ -31,8 +29,6 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 	for _, d := range secpDataTable {
 		privB, _ := hex.DecodeString(d.priv)
 		pubB, _ := hex.DecodeString(d.pub)
-		addrBbz, _, _ := base58.CheckDecode(d.addr)
-		addrB := Address{addrBbz, ""}
 		addrDecoded := Address{}
 		err := addrDecoded.FromString(d.bech32addr)
 		if err != nil {
@@ -42,6 +38,7 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		copy(priv[:], privB)
 
 		pubT := priv.PubKey().(PubKeySecp256k1)
+		pubT.humanReadable = "csmspub"
 		pubDeserialized := priv.PubKey().(PubKeySecp256k1)
 		err = pubDeserialized.FromString(d.bech32pub)
 		if err != nil {
@@ -56,7 +53,6 @@ func TestPubKeySecp256k1Address(t *testing.T) {
 		assert.Equal(t, addr.String(), d.bech32addr)
 		assert.Equal(t, addr, addrDecoded)
 		assert.Equal(t, pub, pubB, "Expected pub keys to match")
-		assert.Equal(t, addr, addrB, "Expected addresses to match")
 	}
 }
 

--- a/wire.go
+++ b/wire.go
@@ -16,6 +16,8 @@ func init() {
 }
 
 func RegisterWire(cdc *wire.Codec) {
+	cdc.RegisterConcrete(Address{},
+		"com.tendermint.wire.Address", nil)
 	cdc.RegisterInterface((*PubKey)(nil), nil)
 	cdc.RegisterConcrete(PubKeyEd25519{},
 		"com.tendermint.wire.PubKeyEd25519", nil)


### PR DESCRIPTION
Implements #65 

Adds bech32cosmos as dependency in glide
Turn Address into a struct with an anonymous field to allow for method overrides
Added change String function to do bech32