### PR TITLE
Make concrete registered name be tendermint/*

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -18,19 +18,19 @@ func init() {
 func RegisterAmino(cdc *amino.Codec) {
 	cdc.RegisterInterface((*PubKey)(nil), nil)
 	cdc.RegisterConcrete(PubKeyEd25519{},
-		"com.tendermint.amino.PubKeyEd25519", nil)
+		"tendermint/PubKeyEd25519", nil)
 	cdc.RegisterConcrete(PubKeySecp256k1{},
-		"com.tendermint.amino.PubKeySecp256k1", nil)
+		"tendermint/PubKeySecp256k1", nil)
 
 	cdc.RegisterInterface((*PrivKey)(nil), nil)
 	cdc.RegisterConcrete(PrivKeyEd25519{},
-		"com.tendermint.amino.PrivKeyEd25519", nil)
+		"tendermint/PrivKeyEd25519", nil)
 	cdc.RegisterConcrete(PrivKeySecp256k1{},
-		"com.tendermint.amino.PrivKeySecp256k1", nil)
+		"tendermint/PrivKeySecp256k1", nil)
 
 	cdc.RegisterInterface((*Signature)(nil), nil)
 	cdc.RegisterConcrete(SignatureEd25519{},
-		"com.tendermint.amino.SignatureKeyEd25519", nil)
+		"tendermint/SignatureKeyEd25519", nil)
 	cdc.RegisterConcrete(SignatureSecp256k1{},
-		"com.tendermint.amino.SignatureKeySecp256k1", nil)
+		"tendermint/SignatureKeySecp256k1", nil)
 }

--- a/signature_test.go
+++ b/signature_test.go
@@ -54,12 +54,12 @@ func TestSignatureEncodings(t *testing.T) {
 		{
 			privKey:   GenPrivKeyEd25519(),
 			sigSize:   ed25519.SignatureSize,
-			sigPrefix: [4]byte{0xc8, 0x5d, 0xf4, 0xba},
+			sigPrefix: [4]byte{0x3d, 0xa1, 0xdb, 0x2a},
 		},
 		{
 			privKey:   GenPrivKeySecp256k1(),
 			sigSize:   0, // unknown
-			sigPrefix: [4]byte{0xc6, 0xa0, 0xa, 0x42},
+			sigPrefix: [4]byte{0x16, 0xe1, 0xfe, 0xea},
 		},
 	}
 


### PR DESCRIPTION
doesn't make sense to enforce our domain if we want others to implement it.
so lets just call our namespace "tendermint".  

everything should be registered under tendermint/*