### PR TITLE
make sure the passed argument in nano.parseDigest is at least 4 bytes

### DIFF
--- a/_nano/sign.go
+++ b/_nano/sign.go
@@ -40,6 +40,9 @@ func generateSignRequests(payload []byte) [][]byte {
 }
 
 func parseDigest(resp []byte) (key, sig []byte, err error) {
+	if len(resp) < 4 {
+		return nil, nil, errors.Errorf("Incorrect length: %d", len(resp))
+	}
 	if resp[0] != App || resp[1] != Digest {
 		return nil, nil, errors.New("Invalid header")
 	}


### PR DESCRIPTION
before accessing its contents 

resolves #93 