### PR TITLE
revert some changes: testvectors and re-add lenght prefix

### DIFF
--- a/merkle/doc.go
+++ b/merkle/doc.go
@@ -1,0 +1,31 @@
+/*
+Package merkle computes a deterministic minimal height Merkle tree hash.
+If the number of items is not a power of two, some leaves
+will be at different levels. Tries to keep both sides of
+the tree the same size, but the left may be one greater.
+
+Use this for short deterministic trees, such as the validator list.
+For larger datasets, use IAVLTree.
+
+Be aware that the current implementation by itself does not prevent
+second pre-image attacks. Hence, use this library with caution.
+Otherwise you might run into similar issues as, e.g., in early Bitcoin:
+https://bitcointalk.org/?topic=102395
+
+                        *
+                       / \
+                     /     \
+                   /         \
+                 /             \
+                *               *
+               / \             / \
+              /   \           /   \
+             /     \         /     \
+            *       *       *       h6
+           / \     / \     / \
+          h0  h1  h2  h3  h4  h5
+
+TODO(ismail): add 2nd pre-image protection or clarify further on how we use this and why this secure.
+
+*/
+package merkle

--- a/merkle/simple_map.go
+++ b/merkle/simple_map.go
@@ -20,7 +20,7 @@ func newSimpleMap() *simpleMap {
 	}
 }
 
-// Hash the key and value and append to the kv pairs
+// Set hashes the key and value and appends it to the kv pairs.
 func (sm *simpleMap) Set(key string, value Hasher) {
 	sm.sorted = false
 
@@ -38,7 +38,7 @@ func (sm *simpleMap) Set(key string, value Hasher) {
 	})
 }
 
-// Merkle root hash of items sorted by key
+// Hash Merkle root hash of items sorted by key
 // (UNSTABLE: and by value too if duplicate key).
 func (sm *simpleMap) Hash() []byte {
 	sm.Sort()
@@ -65,13 +65,22 @@ func (sm *simpleMap) KVPairs() cmn.KVPairs {
 //----------------------------------------
 
 // A local extension to KVPair that can be hashed.
-// XXX: key and value must already be hashed -
-// otherwise the kvpair ("abc", "def") would give the same result
-// as ("ab", "cdef") since we're not using length-prefixing.
+// XXX: key and value do not need to already be hashed -
+// the kvpair ("abc", "def") would not give the same result
+// as ("ab", "cdef") as we're using length-prefixing.
 type kvPair cmn.KVPair
 
 func (kv kvPair) Hash() []byte {
-	return SimpleHashFromTwoHashes(kv.Key, kv.Value)
+	hasher := tmhash.New()
+	err := encodeByteSlice(hasher, kv.Key)
+	if err != nil {
+			panic(err)
+		}
+	err = encodeByteSlice(hasher, kv.Value)
+	if err != nil {
+			panic(err)
+		}
+	return hasher.Sum(nil)
 }
 
 func hashKVPairs(kvs cmn.KVPairs) []byte {

--- a/merkle/simple_map_test.go
+++ b/merkle/simple_map_test.go
@@ -15,39 +15,39 @@ func (str strHasher) Hash() []byte {
 
 func TestSimpleMap(t *testing.T) {
 	{
-		db := NewSimpleMap()
+		db := newSimpleMap()
 		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "3dafc06a52039d029be57c75c9d16356a4256ef4", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "f544bcb4338dab8c5d5da4e8dfde617691da735c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
-		db := NewSimpleMap()
+		db := newSimpleMap()
 		db.Set("key1", strHasher("value2"))
-		assert.Equal(t, "03eb5cfdff646bc4e80fec844e72fd248a1c6b2c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "8a275766d89cb1788357b197b0aad91f4caf09fb", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
-		db := NewSimpleMap()
+		db := newSimpleMap()
 		db.Set("key1", strHasher("value1"))
 		db.Set("key2", strHasher("value2"))
-		assert.Equal(t, "acc3971eab8513171cc90ce8b74f368c38f9657d", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "4a768df000f38b9d50d504b455c3a089b9c365fc", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
-		db := NewSimpleMap()
+		db := newSimpleMap()
 		db.Set("key2", strHasher("value2")) // NOTE: out of order
 		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "acc3971eab8513171cc90ce8b74f368c38f9657d", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "4a768df000f38b9d50d504b455c3a089b9c365fc", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
-		db := NewSimpleMap()
+		db := newSimpleMap()
 		db.Set("key1", strHasher("value1"))
 		db.Set("key2", strHasher("value2"))
 		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "0cd117ad14e6cd22edcd9aa0d84d7063b54b862f", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "0681dc46eee71cf1e101bba27e865bcf27cfd85c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
-		db := NewSimpleMap()
+		db := newSimpleMap()
 		db.Set("key2", strHasher("value2")) // NOTE: out of order
 		db.Set("key1", strHasher("value1"))
 		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "0cd117ad14e6cd22edcd9aa0d84d7063b54b862f", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "0681dc46eee71cf1e101bba27e865bcf27cfd85c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 }

--- a/merkle/simple_map_test.go
+++ b/merkle/simple_map_test.go
@@ -11,44 +11,46 @@ import (
 type strHasher string
 
 func (str strHasher) Hash() []byte {
-	return tmhash.Sum([]byte(str))
+	h := tmhash.New()
+	h.Write([]byte(str))
+	return h.Sum(nil)
 }
 
 func TestSimpleMap(t *testing.T) {
 	{
 		db := newSimpleMap()
 		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "f544bcb4338dab8c5d5da4e8dfde617691da735c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "3dafc06a52039d029be57c75c9d16356a4256ef4", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := newSimpleMap()
 		db.Set("key1", strHasher("value2"))
-		assert.Equal(t, "8a275766d89cb1788357b197b0aad91f4caf09fb", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "03eb5cfdff646bc4e80fec844e72fd248a1c6b2c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := newSimpleMap()
 		db.Set("key1", strHasher("value1"))
 		db.Set("key2", strHasher("value2"))
-		assert.Equal(t, "4a768df000f38b9d50d504b455c3a089b9c365fc", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "acc3971eab8513171cc90ce8b74f368c38f9657d", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := newSimpleMap()
 		db.Set("key2", strHasher("value2")) // NOTE: out of order
 		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "4a768df000f38b9d50d504b455c3a089b9c365fc", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "acc3971eab8513171cc90ce8b74f368c38f9657d", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := newSimpleMap()
 		db.Set("key1", strHasher("value1"))
 		db.Set("key2", strHasher("value2"))
 		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "0681dc46eee71cf1e101bba27e865bcf27cfd85c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "0cd117ad14e6cd22edcd9aa0d84d7063b54b862f", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := newSimpleMap()
 		db.Set("key2", strHasher("value2")) // NOTE: out of order
 		db.Set("key1", strHasher("value1"))
 		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "0681dc46eee71cf1e101bba27e865bcf27cfd85c", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "0cd117ad14e6cd22edcd9aa0d84d7063b54b862f", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 }

--- a/merkle/simple_map_test.go
+++ b/merkle/simple_map_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/go-crypto/tmhash"
 )
 
 type strHasher string
 
 func (str strHasher) Hash() []byte {
-	return SimpleHashFromBytes([]byte(str))
+	return tmhash.Sum([]byte(str))
 }
 
 func TestSimpleMap(t *testing.T) {

--- a/merkle/simple_proof.go
+++ b/merkle/simple_proof.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 )
 
+// SimpleProof represents a simple merkle proof.
 type SimpleProof struct {
 	Aunts [][]byte `json:"aunts"` // Hashes from leaf's sibling to a root's child.
 }
 
+// SimpleProofsFromHashers computes inclusion proof for given items.
 // proofs[0] is the proof for items[0].
 func SimpleProofsFromHashers(items []Hasher) (rootHash []byte, proofs []*SimpleProof) {
 	trails, rootSPN := trailsFromHashers(items)
@@ -22,6 +24,9 @@ func SimpleProofsFromHashers(items []Hasher) (rootHash []byte, proofs []*SimpleP
 	return
 }
 
+// SimpleProofsFromMap generates proofs from a map. The keys/values of the map will be used as the keys/values
+// in the underlying key-value pairs.
+// The keys are sorted before the proofs are computed.
 func SimpleProofsFromMap(m map[string]Hasher) (rootHash []byte, proofs []*SimpleProof) {
 	sm := newSimpleMap()
 	for k, v := range m {
@@ -43,10 +48,13 @@ func (sp *SimpleProof) Verify(index int, total int, leafHash []byte, rootHash []
 	return computedHash != nil && bytes.Equal(computedHash, rootHash)
 }
 
+// String implements the stringer interface for SimpleProof.
+// It is a wrapper around StringIndented.
 func (sp *SimpleProof) String() string {
 	return sp.StringIndented("")
 }
 
+// StringIndented generates a canonical string representation of a SimpleProof.
 func (sp *SimpleProof) StringIndented(indent string) string {
 	return fmt.Sprintf(`SimpleProof{
 %s  Aunts: %X
@@ -90,7 +98,7 @@ func computeHashFromAunts(index int, total int, leafHash []byte, innerHashes [][
 	}
 }
 
-// Helper structure to construct merkle proof.
+// SimpleProofNode is a helper structure to construct merkle proof.
 // The node and the tree is thrown away afterwards.
 // Exactly one of node.Left and node.Right is nil, unless node is the root, in which case both are nil.
 // node.Parent.Hash = hash(node.Hash, node.Right.Hash) or
@@ -102,8 +110,8 @@ type SimpleProofNode struct {
 	Right  *SimpleProofNode // Right sibling (only one of Left,Right is set)
 }
 
-// Starting from a leaf SimpleProofNode, FlattenAunts() will return
-// the inner hashes for the item corresponding to the leaf.
+// FlattenAunts will return the inner hashes for the item corresponding to the leaf,
+// starting from a leaf SimpleProofNode.
 func (spn *SimpleProofNode) FlattenAunts() [][]byte {
 	// Nonrecursive impl.
 	innerHashes := [][]byte{}

--- a/merkle/simple_tree.go
+++ b/merkle/simple_tree.go
@@ -60,6 +60,12 @@ func SimpleHashFromMap(m map[string]Hasher) []byte {
 
 //----------------------------------------------------------------
 
+func SimpleHashFromBytes(bz []byte) []byte {
+	hasher := tmhash.New()
+	hasher.Write(bz)
+	return hasher.Sum(nil)
+}
+
 // Expects hashes!
 func simpleHashFromHashes(hashes [][]byte) []byte {
 	// Recursive impl.

--- a/merkle/simple_tree.go
+++ b/merkle/simple_tree.go
@@ -1,42 +1,24 @@
-/*
-Computes a deterministic minimal height merkle tree hash.
-If the number of items is not a power of two, some leaves
-will be at different levels. Tries to keep both sides of
-the tree the same size, but the left may be one greater.
-
-Use this for short deterministic trees, such as the validator list.
-For larger datasets, use IAVLTree.
-
-                        *
-                       / \
-                     /     \
-                   /         \
-                 /             \
-                *               *
-               / \             / \
-              /   \           /   \
-             /     \         /     \
-            *       *       *       h6
-           / \     / \     / \
-          h0  h1  h2  h3  h4  h5
-
-*/
-
 package merkle
 
 import (
 	"github.com/tendermint/go-crypto/tmhash"
 )
 
-// Hash(left | right). The basic operation of the Merkle tree.
+// SimpleHashFromTwoHashes is the basic operation of the Merkle tree: Hash(left | right).
 func SimpleHashFromTwoHashes(left, right []byte) []byte {
 	var hasher = tmhash.New()
-	hasher.Write(left)
-	hasher.Write(right)
+	err := encodeByteSlice(hasher, left)
+	if err != nil {
+			panic(err)
+		}
+	err = encodeByteSlice(hasher, right)
+	if err != nil {
+			panic(err)
+		}
 	return hasher.Sum(nil)
 }
 
-// Compute a Merkle tree from items that can be hashed.
+// SimpleHashFromHashers computes a Merkle tree from items that can be hashed.
 func SimpleHashFromHashers(items []Hasher) []byte {
 	hashes := make([][]byte, len(items))
 	for i, item := range items {
@@ -46,7 +28,7 @@ func SimpleHashFromHashers(items []Hasher) []byte {
 	return simpleHashFromHashes(hashes)
 }
 
-// Compute a Merkle tree from sorted map.
+// SimpleHashFromMap computes a Merkle tree from sorted map.
 // Like calling SimpleHashFromHashers with
 // `item = []byte(Hash(key) | Hash(value))`,
 // sorted by `item`.

--- a/merkle/simple_tree.go
+++ b/merkle/simple_tree.go
@@ -60,12 +60,6 @@ func SimpleHashFromMap(m map[string]Hasher) []byte {
 
 //----------------------------------------------------------------
 
-func SimpleHashFromBytes(bz []byte) []byte {
-	hasher := tmhash.New()
-	hasher.Write(bz)
-	return hasher.Sum(nil)
-}
-
 // Expects hashes!
 func simpleHashFromHashes(hashes [][]byte) []byte {
 	// Recursive impl.

--- a/merkle/simple_tree_test.go
+++ b/merkle/simple_tree_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/tendermint/tmlibs/test"
 
 	"testing"
+	"github.com/tendermint/go-crypto/tmhash"
 )
 
 type testItem []byte
@@ -21,7 +22,7 @@ func TestSimpleProof(t *testing.T) {
 
 	items := make([]Hasher, total)
 	for i := 0; i < total; i++ {
-		items[i] = testItem(cmn.RandBytes(32))
+		items[i] = testItem(cmn.RandBytes(tmhash.Size))
 	}
 
 	rootHash := SimpleHashFromHashers(items)

--- a/merkle/types.go
+++ b/merkle/types.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// Tree is a Merkle tree interface.
 type Tree interface {
 	Size() (size int)
 	Height() (height int8)
@@ -23,6 +24,7 @@ type Tree interface {
 	IterateRange(start []byte, end []byte, ascending bool, fx func(key []byte, value []byte) (stop bool)) (stopped bool)
 }
 
+// Hasher represents a hashable piece of data which can be hashed in the Tree.
 type Hasher interface {
 	Hash() []byte
 }

--- a/tmhash/hash.go
+++ b/tmhash/hash.go
@@ -5,7 +5,7 @@ import (
 	"hash"
 )
 
-var (
+const (
 	Size      = 20
 	BlockSize = sha256.BlockSize
 )


### PR DESCRIPTION
~~If we still want to remove the encoding / len prefixing, here is a branch I've played around with different approaches and where I just kept the changes that fix the tests / build issues~~~

I reverted some changes here: 
- use the original test-vectors from tmlib
- (re)add the encoding / length prefix
- fix the tests

Some documentation:
- document public methods and follow golang documentation best practices
- add a warning (and a TODO) about 2nd preimage attacks (see #107) in a separate file (doc.go)

feel free to merge into your branch (if it might save you some time) or ignore and close 

/cc @ebuchman 