### PR TITLE
SignatureKey -> Signature

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,15 +128,16 @@
 [[projects]]
   name = "github.com/tendermint/go-amino"
   packages = ["."]
-  revision = "42246108ff925a457fb709475070a03dfd3e2b5c"
-  version = "0.9.6"
+  revision = "1715b7b78c65d6adcc5937315be4710234cefe09"
+  version = "0.10.0-rc2"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
   packages = [
     "common",
     "db",
-    "log"
+    "log",
+    "test"
   ]
   revision = "2e24b64fc121dcdf1cabceab8dc2f7257675483c"
   version = "v0.8.1"
@@ -153,6 +154,8 @@
   packages = [
     "bcrypt",
     "blowfish",
+    "chacha20poly1305",
+    "internal/chacha20",
     "nacl/secretbox",
     "openpgp/armor",
     "openpgp/errors",
@@ -166,6 +169,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f9ccfa2cadfcbfb43bf729b871a0ad2f8d4f4acb118cd859e6faf9b24842b840"
+  inputs-digest = "b34cf043cab77178eebff1b7cfce8b31b6c2b6b3318c6d01add271b68f550345"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/go-amino"
-  version = "0.9.6"
+  version = "0.10.0-rc2"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"

--- a/amino.go
+++ b/amino.go
@@ -30,7 +30,7 @@ func RegisterAmino(cdc *amino.Codec) {
 
 	cdc.RegisterInterface((*Signature)(nil), nil)
 	cdc.RegisterConcrete(SignatureEd25519{},
-		"tendermint/SignatureKeyEd25519", nil)
+		"tendermint/SignatureEd25519", nil)
 	cdc.RegisterConcrete(SignatureSecp256k1{},
-		"tendermint/SignatureKeySecp256k1", nil)
+		"tendermint/SignatureSecp256k1", nil)
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -50,6 +50,7 @@ func ExamplePrintRegisteredTypes() {
 	//| PubKeySecp256k1 | tendermint/PubKeySecp256k1 | 0xEB5AE987 | 0x21 |  |
 	//| PrivKeyEd25519 | tendermint/PrivKeyEd25519 | 0xA3288910 | 0x40 |  |
 	//| PrivKeySecp256k1 | tendermint/PrivKeySecp256k1 | 0xE1B0F79B | 0x20 |  |
+	//| PrivKeyLedgerSecp256k1 | tendermint/PrivKeyLedgerSecp256k1 | 0x10CAB393 | variable |  |
 	//| SignatureEd25519 | tendermint/SignatureEd25519 | 0x2031EA53 | 0x40 |  |
 	//| SignatureSecp256k1 | tendermint/SignatureSecp256k1 | 0x7FC4A495 | variable |  |
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,18 @@ func checkAminoJSON(t *testing.T, src interface{}, dst interface{}, isNil bool) 
 	// Unmarshal.
 	err = cdc.UnmarshalJSON(js, dst)
 	require.Nil(t, err, "%+v", err)
+}
+
+func ExamplePrintRegisteredTypes() {
+	cdc.PrintTypes(os.Stdout)
+	// Output: | Type | Name | Prefix | Length | Notes |
+	//| ---- | ---- | ------ | ----- | ------ |
+	//| PubKeyEd25519 | tendermint/PubKeyEd25519 | 0x1624DE64 | 0x20 |  |
+	//| PubKeySecp256k1 | tendermint/PubKeySecp256k1 | 0xEB5AE987 | 0x21 |  |
+	//| PrivKeyEd25519 | tendermint/PrivKeyEd25519 | 0xA3288910 | 0x40 |  |
+	//| PrivKeySecp256k1 | tendermint/PrivKeySecp256k1 | 0xE1B0F79B | 0x20 |  |
+	//| SignatureEd25519 | tendermint/SignatureEd25519 | 0x2031EA53 | 0x40 |  |
+	//| SignatureSecp256k1 | tendermint/SignatureSecp256k1 | 0x7FC4A495 | variable |  |
 }
 
 func TestKeyEncodings(t *testing.T) {

--- a/keys/keybase_test.go
+++ b/keys/keybase_test.go
@@ -33,9 +33,9 @@ func TestKeyManagement(t *testing.T) {
 	assert.Empty(t, l)
 
 	// create some keys
-	_, err = cstore.Get(n1)
-	assert.NotNil(t, err)
-	i, _, err := cstore.Create(n1, p1, algo)
+	i, err := cstore.Get(n1)
+	assert.Equal(t, i, keys.Info{})
+	i, _, err = cstore.Create(n1, p1, algo)
 	require.Equal(t, n1, i.Name)
 	require.Nil(t, err)
 	_, _, err = cstore.Create(n2, p2, algo)
@@ -44,8 +44,8 @@ func TestKeyManagement(t *testing.T) {
 	// we can get these keys
 	i2, err := cstore.Get(n2)
 	assert.Nil(t, err)
-	_, err = cstore.Get(n3)
-	assert.NotNil(t, err)
+	i, err = cstore.Get(n3)
+	assert.Equal(t, i, keys.Info{})
 
 	// list shows them in order
 	keyS, err := cstore.List()
@@ -64,8 +64,8 @@ func TestKeyManagement(t *testing.T) {
 	keyS, err = cstore.List()
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(keyS))
-	_, err = cstore.Get(n1)
-	assert.NotNil(t, err)
+	i, err = cstore.Get(n1)
+	assert.Equal(t, i, keys.Info{})
 
 	// make sure that it only signs with the right password
 	// tx := mock.NewSig([]byte("mytransactiondata"))
@@ -370,8 +370,8 @@ func TestSeedPhrase(t *testing.T) {
 	// now, let us delete this key
 	err = cstore.Delete(n1, p1)
 	require.Nil(t, err, "%+v", err)
-	_, err = cstore.Get(n1)
-	require.NotNil(t, err)
+	i, err := cstore.Get(n1)
+	require.Equal(t, i, keys.Info{}, "expected empty info")
 
 	// let us re-create it from the seed-phrase
 	newInfo, err := cstore.Recover(n2, p2, seed)

--- a/signature_test.go
+++ b/signature_test.go
@@ -4,9 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/ed25519"
-	amino "github.com/tendermint/go-amino"
 )
 
 func TestSignAndValidateEd25519(t *testing.T) {
@@ -43,66 +40,4 @@ func TestSignAndValidateSecp256k1(t *testing.T) {
 	sig = sigEd
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
-}
-
-func TestSignatureEncodings(t *testing.T) {
-	cases := []struct {
-		privKey   PrivKey
-		sigSize   int
-		sigPrefix amino.PrefixBytes
-	}{
-		{
-			privKey:   GenPrivKeyEd25519(),
-			sigSize:   ed25519.SignatureSize,
-			sigPrefix: [4]byte{0x3d, 0xa1, 0xdb, 0x2a},
-		},
-		{
-			privKey:   GenPrivKeySecp256k1(),
-			sigSize:   0, // unknown
-			sigPrefix: [4]byte{0x16, 0xe1, 0xfe, 0xea},
-		},
-	}
-
-	for _, tc := range cases {
-		// note we embed them from the beginning....
-		pubKey := tc.privKey.PubKey()
-
-		msg := CRandBytes(128)
-		sig := tc.privKey.Sign(msg)
-
-		// store as amino
-		bin, err := cdc.MarshalBinaryBare(sig)
-		require.Nil(t, err, "%+v", err)
-		if tc.sigSize != 0 {
-			// Q: where is 1 byte coming from?
-			assert.Equal(t, tc.sigSize+amino.PrefixBytesLen+1, len(bin))
-		}
-		assert.Equal(t, tc.sigPrefix[:], bin[0:amino.PrefixBytesLen])
-
-		// and back
-		sig2 := Signature(nil)
-		err = cdc.UnmarshalBinaryBare(bin, &sig2)
-		require.Nil(t, err, "%+v", err)
-		assert.EqualValues(t, sig, sig2)
-		assert.True(t, pubKey.VerifyBytes(msg, sig2))
-
-		/*
-			// store as json
-			js, err := data.ToJSON(sig)
-			require.Nil(t, err, "%+v", err)
-			assert.True(t, strings.Contains(string(js), tc.sigName))
-
-			// and back
-			sig3 := Signature{}
-			err = data.FromJSON(js, &sig3)
-			require.Nil(t, err, "%+v", err)
-			assert.EqualValues(t, sig, sig3)
-			assert.True(t, pubKey.VerifyBytes(msg, sig3))
-
-			// and make sure we can textify it
-			text, err := data.ToText(sig)
-			require.Nil(t, err, "%+v", err)
-			assert.True(t, strings.HasPrefix(text, tc.sigName))
-		*/
-	}
 }


### PR DESCRIPTION
Ref https://github.com/tendermint/go-crypto/issues/84

@Liamsi can you add https://github.com/tendermint/go-crypto/issues/88 so we can get the updated info for the docs: https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/encoding.md#pubkeyed25519

We can probably simplify those docs a bunch by just using a table instead of all the verbosity I have there now ...